### PR TITLE
Add whitelist for items to bypass spawn protection

### DIFF
--- a/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
+++ b/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
@@ -133,7 +133,7 @@
 +                if(CauldronCommand.debug)System.out.println("Item getItem() is null");
 +                        return false;
 +                }
-+                if( outsideOfVanillaRange(Item.getIdFromItem(ep.getHeldItem().getItem()))) {
++                if( outsideOfVanillaRange(Item.getIdFromItem(ep.getHeldItem().getItem())) && !CrucibleConfigs.configs.crucible_protectedWorldWhitelist.contains(Item.getIdFromItem(ep.getHeldItem().getItem()))) {
 +                        if(ep instanceof EntityPlayerMP) {
 +                                EntityPlayerMP mp = (EntityPlayerMP)ep;
 +                                mp.addChatComponentMessage(new ChatComponentText("You cannot use that item here."));

--- a/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
+++ b/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
@@ -67,7 +67,7 @@
          PlayerEvent.HarvestCheck event = new PlayerEvent.HarvestCheck(player, block, success);
          MinecraftForge.EVENT_BUS.post(event);
          return event.success;
-@@ -80,27 +105,219 @@
+@@ -80,27 +105,224 @@
      @Deprecated // Location version below
      public static float getBreakSpeed(EntityPlayer player, Block block, int metadata, float original)
      {
@@ -113,15 +113,19 @@
 +        {
 +                 return MinecraftServer.getServer().getConfigurationManager().func_152596_g(ep.getGameProfile());
 +        }
++        
++        public static boolean isItemIdAllowed(int itemId) {
++                return CrucibleConfigs.configs.crucible_protectedWorldWhitelist_invert ^ CrucibleConfigs.configs.crucible_protectedWorldWhitelist.contains(itemId);
++        }
 +
 +        public static boolean nonVanilla(EntityPlayer ep)
 +        {
 +                if (ep == null)
 +                {
-+                if(CauldronCommand.debug)System.out.println("EntityPlayer is null");
++                if (CauldronCommand.debug)System.out.println("EntityPlayer is null");
 +                        return false;
 +                }
-+                if(isOp(ep)) return false;
++                if (isOp(ep)) return false;
 +                if (ep.getHeldItem() == null)
 +                {
 +                        if (CauldronCommand.debug)
@@ -130,10 +134,11 @@
 +                }
 +                if (ep.getHeldItem().getItem() == null)
 +                {
-+                if(CauldronCommand.debug)System.out.println("Item getItem() is null");
++                if (CauldronCommand.debug)System.out.println("Item getItem() is null");
 +                        return false;
 +                }
-+                if( outsideOfVanillaRange(Item.getIdFromItem(ep.getHeldItem().getItem())) && !CrucibleConfigs.configs.crucible_protectedWorldWhitelist.contains(Item.getIdFromItem(ep.getHeldItem().getItem()))) {
++                int itemId = Item.getIdFromItem(ep.getHeldItem().getItem());
++                if (outsideOfVanillaRange(itemId) && !isItemIdAllowed(itemId)))) {
 +                        if(ep instanceof EntityPlayerMP) {
 +                                EntityPlayerMP mp = (EntityPlayerMP)ep;
 +                                mp.addChatComponentMessage(new ChatComponentText("You cannot use that item here."));
@@ -291,7 +296,7 @@
      public static void onPlayerDestroyItem(EntityPlayer player, ItemStack stack)
      {
          MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack));
-@@ -182,30 +399,64 @@
+@@ -182,30 +404,64 @@
          return MinecraftForge.EVENT_BUS.post(new EntityStruckByLightningEvent(entity, bolt));
      }
  

--- a/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
+++ b/patches/net/minecraftforge/event/ForgeEventFactory.java.patch
@@ -115,7 +115,7 @@
 +        }
 +        
 +        public static boolean isItemIdAllowed(int itemId) {
-+                return CrucibleConfigs.configs.crucible_protectedWorldWhitelist_invert ^ CrucibleConfigs.configs.crucible_protectedWorldWhitelist.contains(itemId);
++                return CrucibleConfigs.configs.crucible_protectedWorldWhitelistInvert ^ CrucibleConfigs.configs.crucible_protectedWorldWhitelist.contains(itemId);
 +        }
 +
 +        public static boolean nonVanilla(EntityPlayer ep)
@@ -138,7 +138,7 @@
 +                        return false;
 +                }
 +                int itemId = Item.getIdFromItem(ep.getHeldItem().getItem());
-+                if (outsideOfVanillaRange(itemId) && !isItemIdAllowed(itemId)))) {
++                if (outsideOfVanillaRange(itemId) && !isItemIdAllowed(itemId)) {
 +                        if(ep instanceof EntityPlayerMP) {
 +                                EntityPlayerMP mp = (EntityPlayerMP)ep;
 +                                mp.addChatComponentMessage(new ChatComponentText("You cannot use that item here."));

--- a/src/main/java/io/github/crucible/CrucibleConfigs.java
+++ b/src/main/java/io/github/crucible/CrucibleConfigs.java
@@ -148,6 +148,9 @@ public class CrucibleConfigs extends YamlConfig {
     @Comment("List of numeric item IDs for modded items that can be used in protected worlds")
     public List<Integer> crucible_protectedWorldWhitelist = Collections.emptyList();
 
+    @Comment("Invert the protection whitelist and use it as a blacklist.")
+    public boolean crucible_protectedWorldWhitelistInvert = false;
+
     @Comment("Attempts to reduce console spam by removing \"useless\" logs.")
     public boolean crucible_logging_reduceSpam = false;
 

--- a/src/main/java/io/github/crucible/CrucibleConfigs.java
+++ b/src/main/java/io/github/crucible/CrucibleConfigs.java
@@ -145,6 +145,9 @@ public class CrucibleConfigs extends YamlConfig {
     @Comment("List of world names where the usage of modded itens and blocks will be disabled for ")
     public List<String> crucible_protectedWorld = Collections.singletonList("spawn");
 
+    @Comment("List of numeric item IDs for modded items that can be used in protected worlds")
+    public List<Integer> crucible_protectedWorldWhitelist = Collections.emptyList();
+
     @Comment("Attempts to reduce console spam by removing \"useless\" logs.")
     public boolean crucible_logging_reduceSpam = false;
 


### PR DESCRIPTION
This will let server owners choose which modded items bypass spawn protection, which could be useful for servers with mines in the spawn world to selectively allow modded pickaxes, for example.