### PR TITLE
Increase java build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Advantages over Thermos:
 + You can see more changes in the [releases](https://github.com/CrucibleMC/Crucible/releases) changelog.
 
 ## Build Requirements
-* Java 8u101 JDK or higher
+* Java 8u141 JDK or higher
 * Linux (apparently the project breaks on Windows).
 * `JAVA_HOME` defined on your OS
 


### PR DESCRIPTION
https://letsencrypt.org/docs/certificate-compatibility/#:~:text=with%20updates%20applied)-,java%208%20%3E%3D%208u141,-Java%207%20%3E%3D%207u151

ISRG Root X1 (Lets Encrypt) wasn't added until 8u141