### PR TITLE
Improve RecurrentComplexTransformer stability.

### DIFF
--- a/src/main/java/io/github/crucible/patches/RecurrentComplexTransformer.java
+++ b/src/main/java/io/github/crucible/patches/RecurrentComplexTransformer.java
@@ -16,6 +16,7 @@ public class RecurrentComplexTransformer implements Transformer {
             InsnList instructions = asm.method("ofTypes", "([Lnet/minecraftforge/common/BiomeDictionary$Type;)Ljava/lang/String;").instructions();
 
             AbstractInsnNode abstractInsnNode = instructions.getFirst();
+            boolean appliedPatch = false;
             while (abstractInsnNode != null) {
                 if (abstractInsnNode.getOpcode() == INVOKESTATIC) {
                     MethodInsnNode methodInsnNode = (MethodInsnNode) abstractInsnNode;
@@ -24,9 +25,14 @@ public class RecurrentComplexTransformer implements Transformer {
                             "(Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;"
                                     .equals(methodInsnNode.desc)) {
                         methodInsnNode.owner = "io/github/crucible/patches/Hook";
+                        appliedPatch = true;
                     }
                 }
                 abstractInsnNode = abstractInsnNode.getNext();
+            }
+            if (!appliedPatch) {
+                System.out.println("[Crucible] RecurrentComplexTransformer: " +
+                        "unable to find joptsimple.internal.Strings#join(), ignoring it!");
             }
 
 //            InsnList toAdd = new InsnList();

--- a/src/main/java/io/github/crucible/patches/RecurrentComplexTransformer.java
+++ b/src/main/java/io/github/crucible/patches/RecurrentComplexTransformer.java
@@ -1,17 +1,12 @@
 package io.github.crucible.patches;
 
-import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
-import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
-import org.objectweb.asm.tree.TypeInsnNode;
 import pw.prok.imagine.asm.ImagineASM;
 import pw.prok.imagine.asm.Transformer;
 
-import java.util.Iterator;
-import java.util.List;
-
-import static org.objectweb.asm.Opcodes.*;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 
 @Transformer.RegisterTransformer
 public class RecurrentComplexTransformer implements Transformer {
@@ -19,8 +14,20 @@ public class RecurrentComplexTransformer implements Transformer {
     public void transform(ImagineASM asm) {
         if (asm.is("ivorius.reccomplex.structures.generic.matchers.BiomeMatcher")) {
             InsnList instructions = asm.method("ofTypes", "([Lnet/minecraftforge/common/BiomeDictionary$Type;)Ljava/lang/String;").instructions();
-            instructions.set(instructions.get(12),
-                    new MethodInsnNode(INVOKESTATIC, "io/github/crucible/patches/Hook","join","(Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;", false));
+
+            AbstractInsnNode abstractInsnNode = instructions.getFirst();
+            while (abstractInsnNode != null) {
+                if (abstractInsnNode.getOpcode() == INVOKESTATIC) {
+                    MethodInsnNode methodInsnNode = (MethodInsnNode) abstractInsnNode;
+                    if ("joptsimple/internal/Strings".equals(methodInsnNode.owner) &&
+                            "join".equals(methodInsnNode.name) &&
+                            "(Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;"
+                                    .equals(methodInsnNode.desc)) {
+                        methodInsnNode.owner = "io/github/crucible/patches/Hook";
+                    }
+                }
+                abstractInsnNode = abstractInsnNode.getNext();
+            }
 
 //            InsnList toAdd = new InsnList();
 //            toAdd.add(new MethodInsnNode(INVOKESTATIC, "io/github/crucible/patches/Hook","join","(Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;", false));


### PR DESCRIPTION
Hi, I'm Fox2Code, I help a Modded network from time to time.
One of the server couldn't start with the latest version of crucible due to `RecurrentComplexTransformer` being unstable. 

So instead to force setting an opcode at a specific index without any check,
I just replace the owner from `joptsimple/internal/Strings` to `io/github/crucible/patches/Hook` if there is a match,
since the name and descriptor are the same there is no need to touch them.

This make the transformer much more stable, as it only apply the patch if needed,
and also remove the instruction index hard-coding, also making the transformer more flexible.