### PR TITLE
[Wiki] Adding ForgeRestrictor

### DIFF
--- a/knowledge/Working Mods and Plugins.md
+++ b/knowledge/Working Mods and Plugins.md
@@ -1,1 +1,6 @@
 # Working Mods and Plugins
+    
+### ForgeRestrictor
+Author: [KaiKikuchi](https://github.com/KaiKikuchi) <br>
+Origiinal Girhub URL: _Not available, Only on wayback machine [here](https://web.archive.org/web/20180611114227/https://github.com/KaiKikuchi/ForgeRestrictor)_ <br>
+Download: [ForgeRestrictor-1.4-DEV-11.jar](https://cdn.discordapp.com/attachments/899002842847797258/899030688710418452/ForgeRestrictor-1.4-DEV-11.jar) _(last known working file uplaoded to discord server)_

--- a/knowledge/Working Mods and Plugins.md
+++ b/knowledge/Working Mods and Plugins.md
@@ -2,5 +2,5 @@
     
 ### ForgeRestrictor
 Author: [KaiKikuchi](https://github.com/KaiKikuchi) <br>
-Origiinal Girhub URL: _Not available, Only on wayback machine [here](https://web.archive.org/web/20180611114227/https://github.com/KaiKikuchi/ForgeRestrictor)_ <br>
+Original GitHub URL: _Not available, Only on wayback machine [here](https://web.archive.org/web/20180611114227/https://github.com/KaiKikuchi/ForgeRestrictor)_ <br>
 Download: [ForgeRestrictor-1.4-DEV-11.jar](https://cdn.discordapp.com/attachments/899002842847797258/899030688710418452/ForgeRestrictor-1.4-DEV-11.jar) _(last known working file uplaoded to discord server)_


### PR DESCRIPTION
Works perfectly for restricting access to mod blocks or items that may break protection based pugins - like GriefProtection+