### PR TITLE
Fix Multi-Release Jar

### DIFF
--- a/forge/fml/src/main/java/cpw/mods/fml/common/discovery/JarDiscoverer.java
+++ b/forge/fml/src/main/java/cpw/mods/fml/common/discovery/JarDiscoverer.java
@@ -59,7 +59,7 @@ public class JarDiscoverer implements ITypeDiscoverer
             }
             for (ZipEntry ze : Collections.list(jar.entries()))
             {
-                if (ze.getName()!=null && ze.getName().startsWith("__MACOSX"))
+                if (ze.getName()!=null && (ze.getName().startsWith("__MACOSX") || ze.getName().startsWith("META-INF/versions")))
                 {
                     continue;
                 }


### PR DESCRIPTION
If one of the mods or libraries contains classes for newer versions of Java, the older version of ASM will not be able to read them.
The Multi-Release file contains classes for new versions of Java in the `META-INF/versions` folder.
They should be ignored as forge 1.7.10 cannot run on java higher than 8.