### PR TITLE
Fix Multi-Release JARs

### DIFF
--- a/patches/cpw/mods/fml/common/discovery/JarDiscoverer.java.patch
+++ b/patches/cpw/mods/fml/common/discovery/JarDiscoverer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/cpw/mods/fml/common/discovery/JarDiscoverer.java
++++ ../src-work/minecraft/cpw/mods/fml/common/discovery/JarDiscoverer.java
+@@ -59,7 +59,7 @@
+             }
+             for (ZipEntry ze : Collections.list(jar.entries()))
+             {
+-                if (ze.getName()!=null && ze.getName().startsWith("__MACOSX"))
++                if (ze.getName()!=null && (ze.getName().startsWith("__MACOSX") || ze.getName().startsWith("META-INF/versions")))
+                 {
+                     continue;
+                 }


### PR DESCRIPTION
Fixed version of https://github.com/CrucibleMC/Crucible/pull/105

If one of the mods or libraries contains classes for newer versions of Java, the older version of ASM will not be able to read them.
The Multi-Release file contains classes for new versions of Java in the `META-INF/versions` folder.
They should be ignored as forge 1.7.10 cannot run on java higher than 8.