### PR TITLE
Fixed NPE with MFR grinder fake-world

### DIFF
--- a/patches/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/net/minecraft/entity/EntityLiving.java.patch
@@ -58,7 +58,7 @@
                  }
              }
 +            // Cauldron start - Force despawn of entity if a player isn't near
-+            else if (this.worldObj.cauldronConfig.entityDespawnImmediate && this.canDespawn())
++            else if (this.worldObj.cauldronConfig != null && this.worldObj.cauldronConfig.entityDespawnImmediate && this.canDespawn())
 +            {
 +                this.despawn("No Player : Immediate");
 +            }


### PR DESCRIPTION
I've lost logs, so didn't create an issue.

The problem was with random server crashed, especially right after startup.
The crash log was referencing only MC's calls of entity, getting NPE on call of `EntityLiving#despawnEntity`.
After some invistigation with debbuger on live server, I found that MFR's grinder creates World proxy to override `spawnEntityInWorld`, which caused filling of `cauldronConfig` with null and future crash on entity killing.

This simple patch fixed an issue.