### PR TITLE
Fixed Modded enchantments naming for Bukkit Plugins

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_7_R4/enchantments/CraftEnchantment.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_7_R4/enchantments/CraftEnchantment.java
@@ -30,13 +30,13 @@ public class CraftEnchantment extends Enchantment {
         if (StringUtils.containsIgnoreCase(candidate, "Enchantment")) {
             candidate = candidate.replaceFirst("[E|e]nchantment", "");
             // Add underscores at camelCase humps
-            candidate = candidate.replaceAll("([a-z])([A-Z])", "\1_\2").toUpperCase();
+            candidate = candidate.replaceAll("([a-z])([A-Z])", "$1_$2").toUpperCase();
             candidate = addSuffix(candidate.toUpperCase());
             return candidate;
         }
         // fall back to the FQN if naming pattern is broken
         candidate = clz.getName();
-        candidate = candidate.replaceAll("([a-z])([A-Z])", "\1_\2");
+        candidate = candidate.replaceAll("([a-z])([A-Z])", "$1_$2");
         candidate = candidate.replaceAll("\\.", "_");
         candidate = addSuffix(candidate.toUpperCase());
         return candidate;


### PR DESCRIPTION
Simple fix to do proper enchant name generation

Before fix:
![image](https://github.com/CrucibleMC/Crucible/assets/83125752/6b91d8a8-f51c-4461-893e-79a41162d606)
After fix:
![image](https://github.com/CrucibleMC/Crucible/assets/83125752/39ade323-f0cd-4f73-a34e-858ff8c456f4)

