### PR TITLE
WIP: Tick-Distance property

### DIFF
--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -1389,7 +1389,7 @@
 +        // Keep chunks with growth inside of the optimal chunk range
 +        int chunksPerPlayer = Math.min(200, Math.max(1, (int) (((optimalChunks - playerEntities.size()) / (double) playerEntities.size()) + 0.5)));
 +        // Cauldron start - use server view distance instead of capping it at 7
-+        int randRange = this.func_152379_p();
++        int randRange = Math.min(this.getSpigotConfig().tickDistance, this.func_152379_p());
 +        if (randRange < 1)
 +        {
 +            throw new IllegalArgumentException("Too small view radius! edit server.properties and change view-distance to a value > 0.");

--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
+++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
@@ -23,6 +23,7 @@ public class SpigotWorldConfig {
     public double itemMerge;
     public double expMerge;
     public int viewDistance;
+    public int tickDistance;
     public byte mobSpawnRange;
     public int animalActivationRange = 32;
     public int monsterActivationRange = 32;
@@ -145,6 +146,11 @@ public class SpigotWorldConfig {
     private void viewDistance() {
         viewDistance = getInt("view-distance", Bukkit.getViewDistance());
         log("View Distance: " + viewDistance);
+    }
+
+    private void tickDistance() {
+        tickDistance = getInt("tick-distance", Bukkit.getViewDistance());
+        log("Tick Distance: " + tickDistance);
     }
 
     private void mobSpawnRange() {


### PR DESCRIPTION
This change uses the existing mechanism that determines which chunks are considered active based on a notional maximum number of active chunks. This change adds the ability to reduce the tick distance for use on high-load servers.

- This change requires extensive testing
- This change may not account for other uses of view-distance that may be worth considering