### PR TITLE
Fix MapGenStructure saving data globally rather than per world

### DIFF
--- a/patches/net/minecraft/world/gen/structure/MapGenStructure.java.patch
+++ b/patches/net/minecraft/world/gen/structure/MapGenStructure.java.patch
@@ -8,7 +8,7 @@
 +            // Spigot Start
 +            if (p_143027_1_.getSpigotConfig().saveStructureInfo && !this.func_143025_a().equals("Mineshaft")) // Cauldron
 +            {
-+                this.field_143029_e = (MapGenStructureData) p_143027_1_.loadItemData(MapGenStructureData.class, this.func_143025_a());
++                this.field_143029_e = (MapGenStructureData) p_143027_1_.perWorldStorage.loadData(MapGenStructureData.class, this.func_143025_a());
 +            }
 +            else
 +            {


### PR DESCRIPTION
In NTM: Space, NBT structure generation (backported from modern jigsaw structure gen) would spawn structures in all dimensions due to the world save data NBT being stored in global storage rather than per world storage, which is a regression from the Forge patch which changes that behaviour. This PR restores the expected Forge patch behaviour.