### PR TITLE
Feature/backport some bukkitworld api

### DIFF
--- a/bukkit/src/main/java/org/bukkit/util/BoundingBox.java
+++ b/bukkit/src/main/java/org/bukkit/util/BoundingBox.java
@@ -1,0 +1,1067 @@
+package org.bukkit.util;
+
+import org.apache.commons.lang3.Validate;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A mutable axis aligned bounding box (AABB).
+ * <p>
+ * This basically represents a rectangular box (specified by minimum and maximum
+ * corners) that can for example be used to describe the position and extents of
+ * an object (such as an entity, block, or rectangular region) in 3D space. Its
+ * edges and faces are parallel to the axes of the cartesian coordinate system.
+ * <p>
+ * The bounding box may be degenerate (one or more sides having the length 0).
+ * <p>
+ * Because bounding boxes are mutable, storing them long term may be dangerous
+ * if they get modified later. If you want to keep around a bounding box, it may
+ * be wise to call {@link #clone()} in order to get a copy.
+ */
+@SerializableAs("BoundingBox")
+public class BoundingBox implements Cloneable, ConfigurationSerializable {
+
+    /**
+     * Creates a new bounding box using the coordinates of the given vectors as
+     * corners.
+     *
+     * @param corner1 the first corner
+     * @param corner2 the second corner
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Vector corner1, @NotNull Vector corner2) {
+        Validate.notNull(corner1, "Corner1 is null!");
+        Validate.notNull(corner2, "Corner2 is null!");
+        return new BoundingBox(corner1.getX(), corner1.getY(), corner1.getZ(), corner2.getX(), corner2.getY(), corner2.getZ());
+    }
+
+    /**
+     * Creates a new bounding box using the coordinates of the given locations
+     * as corners.
+     *
+     * @param corner1 the first corner
+     * @param corner2 the second corner
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Location corner1, @NotNull Location corner2) {
+        Validate.notNull(corner1, "Corner1 is null!");
+        Validate.notNull(corner2, "Corner2 is null!");
+        Validate.isTrue(Objects.equals(corner1.getWorld(), corner2.getWorld()), "Locations from different worlds!");
+        return new BoundingBox(corner1.getX(), corner1.getY(), corner1.getZ(), corner2.getX(), corner2.getY(), corner2.getZ());
+    }
+
+    /**
+     * Creates a new bounding box using the coordinates of the given blocks as
+     * corners.
+     * <p>
+     * The bounding box will be sized to fully contain both blocks.
+     *
+     * @param corner1 the first corner block
+     * @param corner2 the second corner block
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Block corner1, @NotNull Block corner2) {
+        Validate.notNull(corner1, "Corner1 is null!");
+        Validate.notNull(corner2, "Corner2 is null!");
+        Validate.isTrue(Objects.equals(corner1.getWorld(), corner2.getWorld()), "Blocks from different worlds!");
+
+        int x1 = corner1.getX();
+        int y1 = corner1.getY();
+        int z1 = corner1.getZ();
+        int x2 = corner2.getX();
+        int y2 = corner2.getY();
+        int z2 = corner2.getZ();
+
+        int minX = Math.min(x1, x2);
+        int minY = Math.min(y1, y2);
+        int minZ = Math.min(z1, z2);
+        int maxX = Math.max(x1, x2) + 1;
+        int maxY = Math.max(y1, y2) + 1;
+        int maxZ = Math.max(z1, z2) + 1;
+
+        return new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    /**
+     * Creates a new 1x1x1 sized bounding box containing the given block.
+     *
+     * @param block the block
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Block block) {
+        Validate.notNull(block, "Block is null!");
+        return new BoundingBox(block.getX(), block.getY(), block.getZ(), block.getX() + 1, block.getY() + 1, block.getZ() + 1);
+    }
+
+    /**
+     * Creates a new bounding box using the given center and extents.
+     *
+     * @param center the center
+     * @param x 1/2 the size of the bounding box along the x axis
+     * @param y 1/2 the size of the bounding box along the y axis
+     * @param z 1/2 the size of the bounding box along the z axis
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Vector center, double x, double y, double z) {
+        Validate.notNull(center, "Center is null!");
+        return new BoundingBox(center.getX() - x, center.getY() - y, center.getZ() - z, center.getX() + x, center.getY() + y, center.getZ() + z);
+    }
+
+    /**
+     * Creates a new bounding box using the given center and extents.
+     *
+     * @param center the center
+     * @param x 1/2 the size of the bounding box along the x axis
+     * @param y 1/2 the size of the bounding box along the y axis
+     * @param z 1/2 the size of the bounding box along the z axis
+     * @return the bounding box
+     */
+    @NotNull
+    public static BoundingBox of(@NotNull Location center, double x, double y, double z) {
+        Validate.notNull(center, "Center is null!");
+        return new BoundingBox(center.getX() - x, center.getY() - y, center.getZ() - z, center.getX() + x, center.getY() + y, center.getZ() + z);
+    }
+
+    private double minX;
+    private double minY;
+    private double minZ;
+    private double maxX;
+    private double maxY;
+    private double maxZ;
+
+    /**
+     * Creates a new (degenerate) bounding box with all corner coordinates at
+     * <code>0</code>.
+     */
+    public BoundingBox() {
+        this.resize(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
+    }
+
+    /**
+     * Creates a new bounding box from the given corner coordinates.
+     *
+     * @param x1 the first corner's x value
+     * @param y1 the first corner's y value
+     * @param z1 the first corner's z value
+     * @param x2 the second corner's x value
+     * @param y2 the second corner's y value
+     * @param z2 the second corner's z value
+     */
+    public BoundingBox(double x1, double y1, double z1, double x2, double y2, double z2) {
+        this.resize(x1, y1, z1, x2, y2, z2);
+    }
+
+    /**
+     * Resizes this bounding box.
+     *
+     * @param x1 the first corner's x value
+     * @param y1 the first corner's y value
+     * @param z1 the first corner's z value
+     * @param x2 the second corner's x value
+     * @param y2 the second corner's y value
+     * @param z2 the second corner's z value
+     * @return this bounding box (resized)
+     */
+    @NotNull
+    public BoundingBox resize(double x1, double y1, double z1, double x2, double y2, double z2) {
+        NumberConversions.checkFinite(x1, "x1 not finite");
+        NumberConversions.checkFinite(y1, "y1 not finite");
+        NumberConversions.checkFinite(z1, "z1 not finite");
+        NumberConversions.checkFinite(x2, "x2 not finite");
+        NumberConversions.checkFinite(y2, "y2 not finite");
+        NumberConversions.checkFinite(z2, "z2 not finite");
+
+        this.minX = Math.min(x1, x2);
+        this.minY = Math.min(y1, y2);
+        this.minZ = Math.min(z1, z2);
+        this.maxX = Math.max(x1, x2);
+        this.maxY = Math.max(y1, y2);
+        this.maxZ = Math.max(z1, z2);
+        return this;
+    }
+
+    /**
+     * Gets the minimum x value.
+     *
+     * @return the minimum x value
+     */
+    public double getMinX() {
+        return minX;
+    }
+
+    /**
+     * Gets the minimum y value.
+     *
+     * @return the minimum y value
+     */
+    public double getMinY() {
+        return minY;
+    }
+
+    /**
+     * Gets the minimum z value.
+     *
+     * @return the minimum z value
+     */
+    public double getMinZ() {
+        return minZ;
+    }
+
+    /**
+     * Gets the minimum corner as vector.
+     *
+     * @return the minimum corner as vector
+     */
+    @NotNull
+    public Vector getMin() {
+        return new Vector(minX, minY, minZ);
+    }
+
+    /**
+     * Gets the maximum x value.
+     *
+     * @return the maximum x value
+     */
+    public double getMaxX() {
+        return maxX;
+    }
+
+    /**
+     * Gets the maximum y value.
+     *
+     * @return the maximum y value
+     */
+    public double getMaxY() {
+        return maxY;
+    }
+
+    /**
+     * Gets the maximum z value.
+     *
+     * @return the maximum z value
+     */
+    public double getMaxZ() {
+        return maxZ;
+    }
+
+    /**
+     * Gets the maximum corner as vector.
+     *
+     * @return the maximum corner vector
+     */
+    @NotNull
+    public Vector getMax() {
+        return new Vector(maxX, maxY, maxZ);
+    }
+
+    /**
+     * Gets the width of the bounding box in the x direction.
+     *
+     * @return the width in the x direction
+     */
+    public double getWidthX() {
+        return (this.maxX - this.minX);
+    }
+
+    /**
+     * Gets the width of the bounding box in the z direction.
+     *
+     * @return the width in the z direction
+     */
+    public double getWidthZ() {
+        return (this.maxZ - this.minZ);
+    }
+
+    /**
+     * Gets the height of the bounding box.
+     *
+     * @return the height
+     */
+    public double getHeight() {
+        return (this.maxY - this.minY);
+    }
+
+    /**
+     * Gets the volume of the bounding box.
+     *
+     * @return the volume
+     */
+    public double getVolume() {
+        return (this.getHeight() * this.getWidthX() * this.getWidthZ());
+    }
+
+    /**
+     * Gets the x coordinate of the center of the bounding box.
+     *
+     * @return the center's x coordinate
+     */
+    public double getCenterX() {
+        return (this.minX + this.getWidthX() * 0.5D);
+    }
+
+    /**
+     * Gets the y coordinate of the center of the bounding box.
+     *
+     * @return the center's y coordinate
+     */
+    public double getCenterY() {
+        return (this.minY + this.getHeight() * 0.5D);
+    }
+
+    /**
+     * Gets the z coordinate of the center of the bounding box.
+     *
+     * @return the center's z coordinate
+     */
+    public double getCenterZ() {
+        return (this.minZ + this.getWidthZ() * 0.5D);
+    }
+
+    /**
+     * Gets the center of the bounding box.
+     *
+     * @return the center
+     */
+    @NotNull
+    public Vector getCenter() {
+        return new Vector(this.getCenterX(), this.getCenterY(), this.getCenterZ());
+    }
+
+    /**
+     * Copies another bounding box.
+     *
+     * @param other the other bounding box
+     * @return this bounding box
+     */
+    @NotNull
+    public BoundingBox copy(@NotNull BoundingBox other) {
+        Validate.notNull(other, "Other bounding box is null!");
+        return this.resize(other.getMinX(), other.getMinY(), other.getMinZ(), other.getMaxX(), other.getMaxY(), other.getMaxZ());
+    }
+
+    /**
+     * Expands this bounding box by the given values in the corresponding
+     * directions.
+     * <p>
+     * Negative values will shrink the bounding box in the corresponding
+     * direction. Shrinking will be limited to the point where the affected
+     * opposite faces would meet if the they shrank at uniform speeds.
+     *
+     * @param negativeX the amount of expansion in the negative x direction
+     * @param negativeY the amount of expansion in the negative y direction
+     * @param negativeZ the amount of expansion in the negative z direction
+     * @param positiveX the amount of expansion in the positive x direction
+     * @param positiveY the amount of expansion in the positive y direction
+     * @param positiveZ the amount of expansion in the positive z direction
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(double negativeX, double negativeY, double negativeZ, double positiveX, double positiveY, double positiveZ) {
+        if (negativeX == 0.0D && negativeY == 0.0D && negativeZ == 0.0D && positiveX == 0.0D && positiveY == 0.0D && positiveZ == 0.0D) {
+            return this;
+        }
+        double newMinX = this.minX - negativeX;
+        double newMinY = this.minY - negativeY;
+        double newMinZ = this.minZ - negativeZ;
+        double newMaxX = this.maxX + positiveX;
+        double newMaxY = this.maxY + positiveY;
+        double newMaxZ = this.maxZ + positiveZ;
+
+        // limit shrinking:
+        if (newMinX > newMaxX) {
+            double centerX = this.getCenterX();
+            if (newMaxX >= centerX) {
+                newMinX = newMaxX;
+            } else if (newMinX <= centerX) {
+                newMaxX = newMinX;
+            } else {
+                newMinX = centerX;
+                newMaxX = centerX;
+            }
+        }
+        if (newMinY > newMaxY) {
+            double centerY = this.getCenterY();
+            if (newMaxY >= centerY) {
+                newMinY = newMaxY;
+            } else if (newMinY <= centerY) {
+                newMaxY = newMinY;
+            } else {
+                newMinY = centerY;
+                newMaxY = centerY;
+            }
+        }
+        if (newMinZ > newMaxZ) {
+            double centerZ = this.getCenterZ();
+            if (newMaxZ >= centerZ) {
+                newMinZ = newMaxZ;
+            } else if (newMinZ <= centerZ) {
+                newMaxZ = newMinZ;
+            } else {
+                newMinZ = centerZ;
+                newMaxZ = centerZ;
+            }
+        }
+        return this.resize(newMinX, newMinY, newMinZ, newMaxX, newMaxY, newMaxZ);
+    }
+
+    /**
+     * Expands this bounding box uniformly by the given values in both positive
+     * and negative directions.
+     * <p>
+     * Negative values will shrink the bounding box. Shrinking will be limited
+     * to the bounding box's current size.
+     *
+     * @param x the amount of expansion in both positive and negative x
+     * direction
+     * @param y the amount of expansion in both positive and negative y
+     * direction
+     * @param z the amount of expansion in both positive and negative z
+     * direction
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(double x, double y, double z) {
+        return this.expand(x, y, z, x, y, z);
+    }
+
+    /**
+     * Expands this bounding box uniformly by the given values in both positive
+     * and negative directions.
+     * <p>
+     * Negative values will shrink the bounding box. Shrinking will be limited
+     * to the bounding box's current size.
+     *
+     * @param expansion the expansion values
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(@NotNull Vector expansion) {
+        Validate.notNull(expansion, "Expansion is null!");
+        double x = expansion.getX();
+        double y = expansion.getY();
+        double z = expansion.getZ();
+        return this.expand(x, y, z, x, y, z);
+    }
+
+    /**
+     * Expands this bounding box uniformly by the given value in all directions.
+     * <p>
+     * A negative value will shrink the bounding box. Shrinking will be limited
+     * to the bounding box's current size.
+     *
+     * @param expansion the amount of expansion
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(double expansion) {
+        return this.expand(expansion, expansion, expansion, expansion, expansion, expansion);
+    }
+
+    /**
+     * Expands this bounding box in the specified direction.
+     * <p>
+     * The magnitude of the direction will scale the expansion. A negative
+     * expansion value will shrink the bounding box in this direction. Shrinking
+     * will be limited to the bounding box's current size.
+     *
+     * @param dirX the x direction component
+     * @param dirY the y direction component
+     * @param dirZ the z direction component
+     * @param expansion the amount of expansion
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(double dirX, double dirY, double dirZ, double expansion) {
+        if (expansion == 0.0D) return this;
+        if (dirX == 0.0D && dirY == 0.0D && dirZ == 0.0D) return this;
+
+        double negativeX = (dirX < 0.0D ? (-dirX * expansion) : 0.0D);
+        double negativeY = (dirY < 0.0D ? (-dirY * expansion) : 0.0D);
+        double negativeZ = (dirZ < 0.0D ? (-dirZ * expansion) : 0.0D);
+        double positiveX = (dirX > 0.0D ? (dirX * expansion) : 0.0D);
+        double positiveY = (dirY > 0.0D ? (dirY * expansion) : 0.0D);
+        double positiveZ = (dirZ > 0.0D ? (dirZ * expansion) : 0.0D);
+        return this.expand(negativeX, negativeY, negativeZ, positiveX, positiveY, positiveZ);
+    }
+
+    /**
+     * Expands this bounding box in the specified direction.
+     * <p>
+     * The magnitude of the direction will scale the expansion. A negative
+     * expansion value will shrink the bounding box in this direction. Shrinking
+     * will be limited to the bounding box's current size.
+     *
+     * @param direction the direction
+     * @param expansion the amount of expansion
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(@NotNull Vector direction, double expansion) {
+        Validate.notNull(direction, "Direction is null!");
+        return this.expand(direction.getX(), direction.getY(), direction.getZ(), expansion);
+    }
+
+    /**
+     * Expands this bounding box in the direction specified by the given block
+     * face.
+     * <p>
+     * A negative expansion value will shrink the bounding box in this
+     * direction. Shrinking will be limited to the bounding box's current size.
+     *
+     * @param blockFace the block face
+     * @param expansion the amount of expansion
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expand(@NotNull BlockFace blockFace, double expansion) {
+        Validate.notNull(blockFace, "Block face is null!");
+        if (blockFace == BlockFace.SELF) return this;
+
+        return this.expand(blockFace.getDirection(), expansion);
+    }
+
+    /**
+     * Expands this bounding box in the specified direction.
+     * <p>
+     * Negative values will expand the bounding box in the negative direction,
+     * positive values will expand it in the positive direction. The magnitudes
+     * of the direction components determine the corresponding amounts of
+     * expansion.
+     *
+     * @param dirX the x direction component
+     * @param dirY the y direction component
+     * @param dirZ the z direction component
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expandDirectional(double dirX, double dirY, double dirZ) {
+        return this.expand(dirX, dirY, dirZ, 1.0D);
+    }
+
+    /**
+     * Expands this bounding box in the specified direction.
+     * <p>
+     * Negative values will expand the bounding box in the negative direction,
+     * positive values will expand it in the positive direction. The magnitude
+     * of the direction vector determines the amount of expansion.
+     *
+     * @param direction the direction and magnitude of the expansion
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox expandDirectional(@NotNull Vector direction) {
+        Validate.notNull(direction, "Expansion is null!");
+        return this.expand(direction.getX(), direction.getY(), direction.getZ(), 1.0D);
+    }
+
+    /**
+     * Expands this bounding box to contain (or border) the specified position.
+     *
+     * @param posX the x position value
+     * @param posY the y position value
+     * @param posZ the z position value
+     * @return this bounding box (now expanded)
+     * @see #contains(double, double, double)
+     */
+    @NotNull
+    public BoundingBox union(double posX, double posY, double posZ) {
+        double newMinX = Math.min(this.minX, posX);
+        double newMinY = Math.min(this.minY, posY);
+        double newMinZ = Math.min(this.minZ, posZ);
+        double newMaxX = Math.max(this.maxX, posX);
+        double newMaxY = Math.max(this.maxY, posY);
+        double newMaxZ = Math.max(this.maxZ, posZ);
+        if (newMinX == this.minX && newMinY == this.minY && newMinZ == this.minZ && newMaxX == this.maxX && newMaxY == this.maxY && newMaxZ == this.maxZ) {
+            return this;
+        }
+        return this.resize(newMinX, newMinY, newMinZ, newMaxX, newMaxY, newMaxZ);
+    }
+
+    /**
+     * Expands this bounding box to contain (or border) the specified position.
+     *
+     * @param position the position
+     * @return this bounding box (now expanded)
+     * @see #contains(double, double, double)
+     */
+    @NotNull
+    public BoundingBox union(@NotNull Vector position) {
+        Validate.notNull(position, "Position is null!");
+        return this.union(position.getX(), position.getY(), position.getZ());
+    }
+
+    /**
+     * Expands this bounding box to contain (or border) the specified position.
+     *
+     * @param position the position
+     * @return this bounding box (now expanded)
+     * @see #contains(double, double, double)
+     */
+    @NotNull
+    public BoundingBox union(@NotNull Location position) {
+        Validate.notNull(position, "Position is null!");
+        return this.union(position.getX(), position.getY(), position.getZ());
+    }
+
+    /**
+     * Expands this bounding box to contain both this and the given bounding
+     * box.
+     *
+     * @param other the other bounding box
+     * @return this bounding box (now expanded)
+     */
+    @NotNull
+    public BoundingBox union(@NotNull BoundingBox other) {
+        Validate.notNull(other, "Other bounding box is null!");
+        if (this.contains(other)) return this;
+        double newMinX = Math.min(this.minX, other.minX);
+        double newMinY = Math.min(this.minY, other.minY);
+        double newMinZ = Math.min(this.minZ, other.minZ);
+        double newMaxX = Math.max(this.maxX, other.maxX);
+        double newMaxY = Math.max(this.maxY, other.maxY);
+        double newMaxZ = Math.max(this.maxZ, other.maxZ);
+        return this.resize(newMinX, newMinY, newMinZ, newMaxX, newMaxY, newMaxZ);
+    }
+
+    /**
+     * Resizes this bounding box to represent the intersection of this and the
+     * given bounding box.
+     *
+     * @param other the other bounding box
+     * @return this bounding box (now representing the intersection)
+     * @throws IllegalArgumentException if the bounding boxes don't overlap
+     */
+    @NotNull
+    public BoundingBox intersection(@NotNull BoundingBox other) {
+        Validate.notNull(other, "Other bounding box is null!");
+        Validate.isTrue(this.overlaps(other), "The bounding boxes do not overlap!");
+        double newMinX = Math.max(this.minX, other.minX);
+        double newMinY = Math.max(this.minY, other.minY);
+        double newMinZ = Math.max(this.minZ, other.minZ);
+        double newMaxX = Math.min(this.maxX, other.maxX);
+        double newMaxY = Math.min(this.maxY, other.maxY);
+        double newMaxZ = Math.min(this.maxZ, other.maxZ);
+        return this.resize(newMinX, newMinY, newMinZ, newMaxX, newMaxY, newMaxZ);
+    }
+
+    /**
+     * Shifts this bounding box by the given amounts.
+     *
+     * @param shiftX the shift in x direction
+     * @param shiftY the shift in y direction
+     * @param shiftZ the shift in z direction
+     * @return this bounding box (now shifted)
+     */
+    @NotNull
+    public BoundingBox shift(double shiftX, double shiftY, double shiftZ) {
+        if (shiftX == 0.0D && shiftY == 0.0D && shiftZ == 0.0D) return this;
+        return this.resize(this.minX + shiftX, this.minY + shiftY, this.minZ + shiftZ,
+                this.maxX + shiftX, this.maxY + shiftY, this.maxZ + shiftZ);
+    }
+
+    /**
+     * Shifts this bounding box by the given amounts.
+     *
+     * @param shift the shift
+     * @return this bounding box (now shifted)
+     */
+    @NotNull
+    public BoundingBox shift(@NotNull Vector shift) {
+        Validate.notNull(shift, "Shift is null!");
+        return this.shift(shift.getX(), shift.getY(), shift.getZ());
+    }
+
+    /**
+     * Shifts this bounding box by the given amounts.
+     *
+     * @param shift the shift
+     * @return this bounding box (now shifted)
+     */
+    @NotNull
+    public BoundingBox shift(@NotNull Location shift) {
+        Validate.notNull(shift, "Shift is null!");
+        return this.shift(shift.getX(), shift.getY(), shift.getZ());
+    }
+
+    private boolean overlaps(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        return this.minX < maxX && this.maxX > minX
+                && this.minY < maxY && this.maxY > minY
+                && this.minZ < maxZ && this.maxZ > minZ;
+    }
+
+    /**
+     * Checks if this bounding box overlaps with the given bounding box.
+     * <p>
+     * Bounding boxes that are only intersecting at the borders are not
+     * considered overlapping.
+     *
+     * @param other the other bounding box
+     * @return <code>true</code> if overlapping
+     */
+    public boolean overlaps(@NotNull BoundingBox other) {
+        Validate.notNull(other, "Other bounding box is null!");
+        return this.overlaps(other.minX, other.minY, other.minZ, other.maxX, other.maxY, other.maxZ);
+    }
+
+    /**
+     * Checks if this bounding box overlaps with the bounding box that is
+     * defined by the given corners.
+     * <p>
+     * Bounding boxes that are only intersecting at the borders are not
+     * considered overlapping.
+     *
+     * @param min the first corner
+     * @param max the second corner
+     * @return <code>true</code> if overlapping
+     */
+    public boolean overlaps(@NotNull Vector min, @NotNull Vector max) {
+        Validate.notNull(min, "Min is null!");
+        Validate.notNull(max, "Max is null!");
+        double x1 = min.getX();
+        double y1 = min.getY();
+        double z1 = min.getZ();
+        double x2 = max.getX();
+        double y2 = max.getY();
+        double z2 = max.getZ();
+        return this.overlaps(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2),
+                Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2));
+    }
+
+    /**
+     * Checks if this bounding box contains the specified position.
+     * <p>
+     * Positions exactly on the minimum borders of the bounding box are
+     * considered to be inside the bounding box, while positions exactly on the
+     * maximum borders are considered to be outside. This allows bounding boxes
+     * to reside directly next to each other with positions always only residing
+     * in exactly one of them.
+     *
+     * @param x the position's x coordinates
+     * @param y the position's y coordinates
+     * @param z the position's z coordinates
+     * @return <code>true</code> if the bounding box contains the position
+     */
+    public boolean contains(double x, double y, double z) {
+        return x >= this.minX && x < this.maxX
+                && y >= this.minY && y < this.maxY
+                && z >= this.minZ && z < this.maxZ;
+    }
+
+    /**
+     * Checks if this bounding box contains the specified position.
+     * <p>
+     * Positions exactly on the minimum borders of the bounding box are
+     * considered to be inside the bounding box, while positions exactly on the
+     * maximum borders are considered to be outside. This allows bounding boxes
+     * to reside directly next to each other with positions always only residing
+     * in exactly one of them.
+     *
+     * @param position the position
+     * @return <code>true</code> if the bounding box contains the position
+     */
+    public boolean contains(@NotNull Vector position) {
+        Validate.notNull(position, "Position is null!");
+        return this.contains(position.getX(), position.getY(), position.getZ());
+    }
+
+    private boolean contains(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        return this.minX <= minX && this.maxX >= maxX
+                && this.minY <= minY && this.maxY >= maxY
+                && this.minZ <= minZ && this.maxZ >= maxZ;
+    }
+
+    /**
+     * Checks if this bounding box fully contains the given bounding box.
+     *
+     * @param other the other bounding box
+     * @return <code>true</code> if the bounding box contains the given bounding
+     * box
+     */
+    public boolean contains(@NotNull BoundingBox other) {
+        Validate.notNull(other, "Other bounding box is null!");
+        return this.contains(other.minX, other.minY, other.minZ, other.maxX, other.maxY, other.maxZ);
+    }
+
+    /**
+     * Checks if this bounding box fully contains the bounding box that is
+     * defined by the given corners.
+     *
+     * @param min the first corner
+     * @param max the second corner
+     * @return <code>true</code> if the bounding box contains the specified
+     *     bounding box
+     */
+    public boolean contains(@NotNull Vector min, @NotNull Vector max) {
+        Validate.notNull(min, "Min is null!");
+        Validate.notNull(max, "Max is null!");
+        double x1 = min.getX();
+        double y1 = min.getY();
+        double z1 = min.getZ();
+        double x2 = max.getX();
+        double y2 = max.getY();
+        double z2 = max.getZ();
+        return this.contains(Math.min(x1, x2), Math.min(y1, y2), Math.min(z1, z2),
+                Math.max(x1, x2), Math.max(y1, y2), Math.max(z1, z2));
+    }
+
+    /**
+     * Calculates the intersection of this bounding box with the specified line
+     * segment.
+     * <p>
+     * Intersections at edges and corners yield one of the affected block faces
+     * as hit result, but it is not defined which of them.
+     *
+     * @param start the start position
+     * @param direction the ray direction
+     * @param maxDistance the maximum distance
+     * @return the ray trace hit result, or <code>null</code> if there is no hit
+     */
+    @Nullable
+    public RayTraceResult rayTrace(@NotNull Vector start, @NotNull Vector direction, double maxDistance) {
+        Validate.notNull(start, "Start is null!");
+        start.checkFinite();
+        Validate.notNull(direction, "Direction is null!");
+        direction.checkFinite();
+        Validate.isTrue(direction.lengthSquared() > 0, "Direction's magnitude is 0!");
+        if (maxDistance < 0.0D) return null;
+
+        // ray start:
+        double startX = start.getX();
+        double startY = start.getY();
+        double startZ = start.getZ();
+
+        // ray direction:
+        Vector dir = direction.clone().normalizeZeros().normalize();
+        double dirX = dir.getX();
+        double dirY = dir.getY();
+        double dirZ = dir.getZ();
+
+        // saving a few divisions below:
+        // Note: If one of the direction vector components is 0.0, these
+        // divisions result in infinity. But this is not a problem.
+        double divX = 1.0D / dirX;
+        double divY = 1.0D / dirY;
+        double divZ = 1.0D / dirZ;
+
+        double tMin;
+        double tMax;
+        BlockFace hitBlockFaceMin;
+        BlockFace hitBlockFaceMax;
+
+        // intersections with x planes:
+        if (dirX >= 0.0D) {
+            tMin = (this.minX - startX) * divX;
+            tMax = (this.maxX - startX) * divX;
+            hitBlockFaceMin = BlockFace.WEST;
+            hitBlockFaceMax = BlockFace.EAST;
+        } else {
+            tMin = (this.maxX - startX) * divX;
+            tMax = (this.minX - startX) * divX;
+            hitBlockFaceMin = BlockFace.EAST;
+            hitBlockFaceMax = BlockFace.WEST;
+        }
+
+        // intersections with y planes:
+        double tyMin;
+        double tyMax;
+        BlockFace hitBlockFaceYMin;
+        BlockFace hitBlockFaceYMax;
+        if (dirY >= 0.0D) {
+            tyMin = (this.minY - startY) * divY;
+            tyMax = (this.maxY - startY) * divY;
+            hitBlockFaceYMin = BlockFace.DOWN;
+            hitBlockFaceYMax = BlockFace.UP;
+        } else {
+            tyMin = (this.maxY - startY) * divY;
+            tyMax = (this.minY - startY) * divY;
+            hitBlockFaceYMin = BlockFace.UP;
+            hitBlockFaceYMax = BlockFace.DOWN;
+        }
+        if ((tMin > tyMax) || (tMax < tyMin)) {
+            return null;
+        }
+        if (tyMin > tMin) {
+            tMin = tyMin;
+            hitBlockFaceMin = hitBlockFaceYMin;
+        }
+        if (tyMax < tMax) {
+            tMax = tyMax;
+            hitBlockFaceMax = hitBlockFaceYMax;
+        }
+
+        // intersections with z planes:
+        double tzMin;
+        double tzMax;
+        BlockFace hitBlockFaceZMin;
+        BlockFace hitBlockFaceZMax;
+        if (dirZ >= 0.0D) {
+            tzMin = (this.minZ - startZ) * divZ;
+            tzMax = (this.maxZ - startZ) * divZ;
+            hitBlockFaceZMin = BlockFace.NORTH;
+            hitBlockFaceZMax = BlockFace.SOUTH;
+        } else {
+            tzMin = (this.maxZ - startZ) * divZ;
+            tzMax = (this.minZ - startZ) * divZ;
+            hitBlockFaceZMin = BlockFace.SOUTH;
+            hitBlockFaceZMax = BlockFace.NORTH;
+        }
+        if ((tMin > tzMax) || (tMax < tzMin)) {
+            return null;
+        }
+        if (tzMin > tMin) {
+            tMin = tzMin;
+            hitBlockFaceMin = hitBlockFaceZMin;
+        }
+        if (tzMax < tMax) {
+            tMax = tzMax;
+            hitBlockFaceMax = hitBlockFaceZMax;
+        }
+
+        // intersections are behind the start:
+        if (tMax < 0.0D) return null;
+        // intersections are to far away:
+        if (tMin > maxDistance) {
+            return null;
+        }
+
+        // find the closest intersection:
+        double t;
+        BlockFace hitBlockFace;
+        if (tMin < 0.0D) {
+            t = tMax;
+            hitBlockFace = hitBlockFaceMax;
+        } else {
+            t = tMin;
+            hitBlockFace = hitBlockFaceMin;
+        }
+        // reusing the newly created direction vector for the hit position:
+        Vector hitPosition = dir.multiply(t).add(start);
+        return new RayTraceResult(hitPosition, hitBlockFace);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(maxX);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(maxY);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(maxZ);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(minX);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(minY);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(minZ);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof BoundingBox)) return false;
+        BoundingBox other = (BoundingBox) obj;
+        if (Double.doubleToLongBits(maxX) != Double.doubleToLongBits(other.maxX)) return false;
+        if (Double.doubleToLongBits(maxY) != Double.doubleToLongBits(other.maxY)) return false;
+        if (Double.doubleToLongBits(maxZ) != Double.doubleToLongBits(other.maxZ)) return false;
+        if (Double.doubleToLongBits(minX) != Double.doubleToLongBits(other.minX)) return false;
+        if (Double.doubleToLongBits(minY) != Double.doubleToLongBits(other.minY)) return false;
+        if (Double.doubleToLongBits(minZ) != Double.doubleToLongBits(other.minZ)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("BoundingBox [minX=");
+        builder.append(minX);
+        builder.append(", minY=");
+        builder.append(minY);
+        builder.append(", minZ=");
+        builder.append(minZ);
+        builder.append(", maxX=");
+        builder.append(maxX);
+        builder.append(", maxY=");
+        builder.append(maxY);
+        builder.append(", maxZ=");
+        builder.append(maxZ);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Creates a copy of this bounding box.
+     *
+     * @return the cloned bounding box
+     */
+    @NotNull
+    @Override
+    public BoundingBox clone() {
+        try {
+            return (BoundingBox) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new Error(e);
+        }
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("minX", minX);
+        result.put("minY", minY);
+        result.put("minZ", minZ);
+        result.put("maxX", maxX);
+        result.put("maxY", maxY);
+        result.put("maxZ", maxZ);
+        return result;
+    }
+
+    @NotNull
+    public static BoundingBox deserialize(@NotNull Map<String, Object> args) {
+        double minX = 0.0D;
+        double minY = 0.0D;
+        double minZ = 0.0D;
+        double maxX = 0.0D;
+        double maxY = 0.0D;
+        double maxZ = 0.0D;
+
+        if (args.containsKey("minX")) {
+            minX = ((Number) args.get("minX")).doubleValue();
+        }
+        if (args.containsKey("minY")) {
+            minY = ((Number) args.get("minY")).doubleValue();
+        }
+        if (args.containsKey("minZ")) {
+            minZ = ((Number) args.get("minZ")).doubleValue();
+        }
+        if (args.containsKey("maxX")) {
+            maxX = ((Number) args.get("maxX")).doubleValue();
+        }
+        if (args.containsKey("maxY")) {
+            maxY = ((Number) args.get("maxY")).doubleValue();
+        }
+        if (args.containsKey("maxZ")) {
+            maxZ = ((Number) args.get("maxZ")).doubleValue();
+        }
+
+        return new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+}

--- a/bukkit/src/main/java/org/bukkit/util/RayTraceResult.java
+++ b/bukkit/src/main/java/org/bukkit/util/RayTraceResult.java
@@ -1,0 +1,163 @@
+package org.bukkit.util;
+
+import org.apache.commons.lang3.Validate;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * The hit result of a ray trace.
+ * <p>
+ * Only the hit position is guaranteed to always be available. The availability
+ * of the other attributes depends on what got hit and on the context in which
+ * the ray trace was performed.
+ */
+public class RayTraceResult {
+
+    private final Vector hitPosition;
+
+    private final Block hitBlock;
+    private final BlockFace hitBlockFace;
+    private final Entity hitEntity;
+
+    private RayTraceResult(@NotNull Vector hitPosition, @Nullable Block hitBlock, @Nullable BlockFace hitBlockFace, @Nullable Entity hitEntity) {
+        Validate.notNull(hitPosition, "Hit position is null!");
+        this.hitPosition = hitPosition.clone();
+        this.hitBlock = hitBlock;
+        this.hitBlockFace = hitBlockFace;
+        this.hitEntity = hitEntity;
+    }
+
+    /**
+     * Creates a RayTraceResult.
+     *
+     * @param hitPosition the hit position
+     */
+    public RayTraceResult(@NotNull Vector hitPosition) {
+        this(hitPosition, null, null, null);
+    }
+
+    /**
+     * Creates a RayTraceResult.
+     *
+     * @param hitPosition the hit position
+     * @param hitBlockFace the hit block face
+     */
+    public RayTraceResult(@NotNull Vector hitPosition, @Nullable BlockFace hitBlockFace) {
+        this(hitPosition, null, hitBlockFace, null);
+    }
+
+    /**
+     * Creates a RayTraceResult.
+     *
+     * @param hitPosition the hit position
+     * @param hitBlock the hit block
+     * @param hitBlockFace the hit block face
+     */
+    public RayTraceResult(@NotNull Vector hitPosition, @Nullable Block hitBlock, @Nullable BlockFace hitBlockFace) {
+        this(hitPosition, hitBlock, hitBlockFace, null);
+    }
+
+    /**
+     * Creates a RayTraceResult.
+     *
+     * @param hitPosition the hit position
+     * @param hitEntity the hit entity
+     */
+    public RayTraceResult(@NotNull Vector hitPosition, @Nullable Entity hitEntity) {
+        this(hitPosition, null, null, hitEntity);
+    }
+
+    /**
+     * Creates a RayTraceResult.
+     *
+     * @param hitPosition the hit position
+     * @param hitEntity the hit entity
+     * @param hitBlockFace the hit block face
+     */
+    public RayTraceResult(@NotNull Vector hitPosition, @Nullable Entity hitEntity, @Nullable BlockFace hitBlockFace) {
+        this(hitPosition, null, hitBlockFace, hitEntity);
+    }
+
+    /**
+     * Gets the exact position of the hit.
+     *
+     * @return a copy of the exact hit position
+     */
+    @NotNull
+    public Vector getHitPosition() {
+        return hitPosition.clone();
+    }
+
+    /**
+     * Gets the hit block.
+     *
+     * @return the hit block, or <code>null</code> if not available
+     */
+    @Nullable
+    public Block getHitBlock() {
+        return hitBlock;
+    }
+
+    /**
+     * Gets the hit block face.
+     *
+     * @return the hit block face, or <code>null</code> if not available
+     */
+    @Nullable
+    public BlockFace getHitBlockFace() {
+        return hitBlockFace;
+    }
+
+    /**
+     * Gets the hit entity.
+     *
+     * @return the hit entity, or <code>null</code> if not available
+     */
+    @Nullable
+    public Entity getHitEntity() {
+        return hitEntity;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + hitPosition.hashCode();
+        result = prime * result + ((hitBlock == null) ? 0 : hitBlock.hashCode());
+        result = prime * result + ((hitBlockFace == null) ? 0 : hitBlockFace.hashCode());
+        result = prime * result + ((hitEntity == null) ? 0 : hitEntity.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof RayTraceResult)) return false;
+        RayTraceResult other = (RayTraceResult) obj;
+        if (!hitPosition.equals(other.hitPosition)) return false;
+        if (!Objects.equals(hitBlock, other.hitBlock)) return false;
+        if (!Objects.equals(hitBlockFace, other.hitBlockFace)) return false;
+        if (!Objects.equals(hitEntity, other.hitEntity)) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("RayTraceResult [hitPosition=");
+        builder.append(hitPosition);
+        builder.append(", hitBlock=");
+        builder.append(hitBlock);
+        builder.append(", hitBlockFace=");
+        builder.append(hitBlockFace);
+        builder.append(", hitEntity=");
+        builder.append(hitEntity);
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/patches/org/bukkit/Location.java.patch
+++ b/patches/org/bukkit/Location.java.patch
@@ -1,0 +1,136 @@
+--- ../src-base/minecraft/org/bukkit/Location.java
++++ ../src-work/minecraft/org/bukkit/Location.java
+@@ -1,13 +1,17 @@
+ package org.bukkit;
+ 
+ import org.bukkit.block.Block;
++import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.util.NumberConversions;
+ import org.bukkit.util.Vector;
+ 
++import java.util.HashMap;
++import java.util.Map;
++
+ /**
+  * Represents a 3-dimensional position in a world
+  */
+-public class Location implements Cloneable {
++public class Location implements Cloneable, ConfigurationSerializable {
+     private World world;
+     private double x;
+     private double y;
+@@ -56,6 +60,15 @@
+     }
+ 
+     /**
++     * Checks if world in this location is present and loaded.
++     *
++     * @return true if is loaded, otherwise false
++     */
++    public boolean isWorldLoaded() {
++        return world != null && Bukkit.getWorld(world.getUID()) != null;
++    }
++
++    /**
+      * Gets the world that this location resides in
+      *
+      * @return World that contains this location
+@@ -548,6 +561,19 @@
+     }
+ 
+     /**
++     * Check if each component of this Location is finite.
++     *
++     * @throws IllegalArgumentException if any component is not finite
++     */
++    public void checkFinite() throws IllegalArgumentException {
++        NumberConversions.checkFinite(x, "x not finite");
++        NumberConversions.checkFinite(y, "y not finite");
++        NumberConversions.checkFinite(z, "z not finite");
++        NumberConversions.checkFinite(pitch, "pitch not finite");
++        NumberConversions.checkFinite(yaw, "yaw not finite");
++    }
++
++    /**
+      * Safely converts a double (location coordinate) to an int (block
+      * coordinate)
+      *
+@@ -557,4 +583,78 @@
+     public static int locToBlock(double loc) {
+         return NumberConversions.floor(loc);
+     }
++
++    @Override
++    @Utility
++    public Map<String, Object> serialize() {
++        Map<String, Object> data = new HashMap<>();
++
++        if (this.world != null) {
++            data.put("world", getWorld().getName());
++        }
++
++        data.put("x", this.x);
++        data.put("y", this.y);
++        data.put("z", this.z);
++
++        data.put("yaw", this.yaw);
++        data.put("pitch", this.pitch);
++
++        return data;
++    }
++
++    /**
++     * Required method for deserialization
++     *
++     * @param args map to deserialize
++     * @return deserialized location
++     * @throws IllegalArgumentException if the world don't exists
++     * @see ConfigurationSerializable
++     */
++    public static Location deserialize(Map<String, Object> args) {
++        World world = null;
++        if (args.containsKey("world")) {
++            world = Bukkit.getWorld((String) args.get("world"));
++            if (world == null) {
++                throw new IllegalArgumentException("unknown world");
++            }
++        }
++
++        return new Location(world, NumberConversions.toDouble(args.get("x")), NumberConversions.toDouble(args.get("y")), NumberConversions.toDouble(args.get("z")), NumberConversions.toFloat(args.get("yaw")), NumberConversions.toFloat(args.get("pitch")));
++    }
++
++    /**
++     * Normalizes the given yaw angle to a value between <code>+/-180</code>
++     * degrees.
++     *
++     * @param yaw the yaw in degrees
++     * @return the normalized yaw in degrees
++     * @see Location#getYaw()
++     */
++    public static float normalizeYaw(float yaw) {
++        yaw %= 360.0f;
++        if (yaw >= 180.0f) {
++            yaw -= 360.0f;
++        } else if (yaw < -180.0f) {
++            yaw += 360.0f;
++        }
++        return yaw;
++    }
++
++    /**
++     * Normalizes the given pitch angle to a value between <code>+/-90</code>
++     * degrees.
++     *
++     * @param pitch the pitch in degrees
++     * @return the normalized pitch in degrees
++     * @see Location#getPitch()
++     */
++    public static float normalizePitch(float pitch) {
++        if (pitch > 90.0f) {
++            pitch = 90.0f;
++        } else if (pitch < -90.0f) {
++            pitch = -90.0f;
++        }
++        return pitch;
++    }
+ }

--- a/patches/org/bukkit/World.java.patch
+++ b/patches/org/bukkit/World.java.patch
@@ -1,15 +1,157 @@
 --- ../src-base/minecraft/org/bukkit/World.java
 +++ ../src-work/minecraft/org/bukkit/World.java
-@@ -17,6 +17,8 @@
+@@ -7,6 +7,8 @@
+ import java.util.List;
+ import java.util.Map;
+ import java.util.UUID;
++import java.util.function.Consumer;
++import java.util.function.Predicate;
+ 
+ import org.bukkit.block.Biome;
+ import org.bukkit.block.Block;
+@@ -15,8 +17,13 @@
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.metadata.Metadatable;
  import org.bukkit.plugin.messaging.PluginMessageRecipient;
++import org.bukkit.util.BoundingBox;
  import org.bukkit.util.Vector;
  
 +import net.minecraft.world.WorldServer;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
 +
  /**
   * Represents a world, which may contain entities, chunks and blocks
   */
-@@ -1155,6 +1157,56 @@
+@@ -138,6 +145,15 @@
+     public boolean isChunkLoaded(Chunk chunk);
+ 
+     /**
++     * Checks if the {@link Chunk} at the specified coordinates is generated
++     *
++     * @param x X-coordinate of the chunk
++     * @param z Z-coordinate of the chunk
++     * @return true if the chunk is generated, otherwise false
++     */
++    public boolean isChunkGenerated(int x, int z);
++
++    /**
+      * Gets an array of all loaded {@link Chunk}s
+      *
+      * @return Chunk[] containing all loaded chunks
+@@ -296,6 +312,18 @@
+     public Item dropItem(Location location, ItemStack item);
+ 
+     /**
++     * Drops an item at the specified {@link Location}
++     * Note that functions will run before the entity is spawned
++     *
++     * @param location Location to drop the item
++     * @param item ItemStack to drop
++     * @param function the function to be run before the entity is spawned.
++     * @return ItemDrop entity created as a result of this method
++     */
++    @NotNull
++    public Item dropItem(@NotNull Location location, @NotNull ItemStack item, @Nullable Consumer<Item> function);
++
++    /**
+      * Drops an item at the specified {@link Location} with a random offset
+      *
+      * @param location Location to drop the item
+@@ -305,6 +333,17 @@
+     public Item dropItemNaturally(Location location, ItemStack item);
+ 
+     /**
++     * Drops an item at the specified {@link Location} with a random offset
++     * Note that functions will run before the entity is spawned
++     *
++     * @param location Location to drop the item
++     * @param item ItemStack to drop
++     * @param function the function to be run before the entity is spawned.
++     * @return ItemDrop entity created as a result of this method
++     */
++    public Item dropItemNaturally(Location location, ItemStack item, Consumer<Item> function);
++
++    /**
+      * Creates an {@link Arrow} entity at the given {@link Location}
+      *
+      * @param location Location to spawn the arrow
+@@ -451,6 +490,74 @@
+     public UUID getUID();
+ 
+     /**
++     * Returns a list of entities within a bounding box centered around a
++     * Location.
++     * <p>
++     * This may not consider entities in currently unloaded chunks. Some
++     * implementations may impose artificial restrictions on the size of the
++     * search bounding box.
++     *
++     * @param location The center of the bounding box
++     * @param x 1/2 the size of the box along x axis
++     * @param y 1/2 the size of the box along y axis
++     * @param z 1/2 the size of the box along z axis
++     * @return the collection of entities near location. This will always be a
++     *      non-null collection.
++     */
++    @NotNull
++    public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
++
++    /**
++     * Returns a list of entities within a bounding box centered around a
++     * Location.
++     * <p>
++     * This may not consider entities in currently unloaded chunks. Some
++     * implementations may impose artificial restrictions on the size of the
++     * search bounding box.
++     *
++     * @param location The center of the bounding box
++     * @param x 1/2 the size of the box along x axis
++     * @param y 1/2 the size of the box along y axis
++     * @param z 1/2 the size of the box along z axis
++     * @param filter only entities that fulfill this predicate are considered,
++     *     or <code>null</code> to consider all entities
++     * @return the collection of entities near location. This will always be a
++     *     non-null collection.
++     */
++    @NotNull
++    public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z, @Nullable Predicate<Entity> filter);
++
++    /**
++     * Returns a list of entities within the given bounding box.
++     * <p>
++     * This may not consider entities in currently unloaded chunks. Some
++     * implementations may impose artificial restrictions on the size of the
++     * search bounding box.
++     *
++     * @param boundingBox the bounding box
++     * @return the collection of entities within the bounding box, will always
++     *     be a non-null collection
++     */
++    @NotNull
++    public Collection<Entity> getNearbyEntities(@NotNull BoundingBox boundingBox);
++
++    /**
++     * Returns a list of entities within the given bounding box.
++     * <p>
++     * This may not consider entities in currently unloaded chunks. Some
++     * implementations may impose artificial restrictions on the size of the
++     * search bounding box.
++     *
++     * @param boundingBox the bounding box
++     * @param filter only entities that fulfill this predicate are considered,
++     *     or <code>null</code> to consider all entities
++     * @return the collection of entities within the bounding box, will always
++     *     be a non-null collection
++     */
++    @NotNull
++    public Collection<Entity> getNearbyEntities(@NotNull BoundingBox boundingBox, @Nullable Predicate<Entity> filter);
++
++    /**
+      * Gets the default spawn {@link Location} of this world
+      *
+      * @return The spawn location of this world
+@@ -1155,6 +1262,56 @@
       */
      public boolean isGameRule(String rule);
  
@@ -66,7 +208,7 @@
      /**
       * Represents various map environment types that a world may be
       */
-@@ -1203,10 +1255,18 @@
+@@ -1203,10 +1360,18 @@
              return lookup.get(id);
          }
  

--- a/patches/org/bukkit/block/BlockFace.java.patch
+++ b/patches/org/bukkit/block/BlockFace.java.patch
@@ -1,0 +1,50 @@
+--- ../src-base/minecraft/org/bukkit/block/BlockFace.java
++++ ../src-work/minecraft/org/bukkit/block/BlockFace.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.block;
+ 
++import org.bukkit.util.Vector;
++
+ /**
+  * Represents the face of a block
+  */
+@@ -67,6 +69,39 @@
+         return modZ;
+     }
+ 
++    /**
++     * Gets the normal vector corresponding to this block face.
++     *
++     * @return the normal vector
++     */
++    public Vector getDirection() {
++        Vector direction = new Vector(modX, modY, modZ);
++        if (modX != 0 || modY != 0 || modZ != 0) {
++            direction.normalize();
++        }
++        return direction;
++    }
++
++    /**
++     * Returns true if this face is aligned with one of the unit axes in 3D
++     * Cartesian space (ie NORTH, SOUTH, EAST, WEST, UP, DOWN).
++     *
++     * @return Cartesian status
++     */
++    public boolean isCartesian() {
++        switch (this) {
++            case NORTH:
++            case SOUTH:
++            case EAST:
++            case WEST:
++            case UP:
++            case DOWN:
++                return true;
++            default:
++                return false;
++        }
++    }
++
+     public BlockFace getOppositeFace() {
+         switch (this) {
+         case NORTH:

--- a/patches/org/bukkit/util/NumberConversions.java.patch
+++ b/patches/org/bukkit/util/NumberConversions.java.patch
@@ -1,0 +1,27 @@
+--- ../src-base/minecraft/org/bukkit/util/NumberConversions.java
++++ ../src-work/minecraft/org/bukkit/util/NumberConversions.java
+@@ -101,4 +101,24 @@
+         }
+         return 0;
+     }
++
++    public static boolean isFinite(double d) {
++        return Math.abs(d) <= Double.MAX_VALUE;
++    }
++
++    public static boolean isFinite(float f) {
++        return Math.abs(f) <= Float.MAX_VALUE;
++    }
++
++    public static void checkFinite(double d, String message) {
++        if (!isFinite(d)) {
++            throw new IllegalArgumentException(message);
++        }
++    }
++
++    public static void checkFinite(float d, String message) {
++        if (!isFinite(d)) {
++            throw new IllegalArgumentException(message);
++        }
++    }
+ }

--- a/patches/org/bukkit/util/Vector.java.patch
+++ b/patches/org/bukkit/util/Vector.java.patch
@@ -1,0 +1,222 @@
+--- ../src-base/minecraft/org/bukkit/util/Vector.java
++++ ../src-work/minecraft/org/bukkit/util/Vector.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.util;
+ 
++import com.google.common.base.Preconditions;
++import com.google.common.primitives.Doubles;
+ import java.util.LinkedHashMap;
+ import java.util.Map;
+ import java.util.Random;
+@@ -303,6 +305,25 @@
+     }
+ 
+     /**
++     * Calculates the cross product of this vector with another without mutating
++     * the original. The cross product is defined as:
++     * <ul>
++     * <li>x = y1 * z2 - y2 * z1
++     * <li>y = z1 * x2 - z2 * x1
++     * <li>z = x1 * y2 - x2 * y1
++     * </ul>
++     *
++     * @param o The other vector
++     * @return a new vector
++     */
++    public Vector getCrossProduct(Vector o) {
++        double x = this.y * o.z - o.y * this.z;
++        double y = this.z * o.x - o.z * this.x;
++        double z = this.x * o.y - o.x * this.y;
++        return new Vector(x, y, z);
++    }
++
++    /**
+      * Converts this vector to a unit vector (a vector with length of 1).
+      *
+      * @return the same vector
+@@ -330,6 +351,18 @@
+     }
+ 
+     /**
++     * Converts each component of value <code>-0.0</code> to <code>0.0</code>.
++     *
++     * @return This vector.
++     */
++    Vector normalizeZeros() {
++        if (x == -0.0D) x = 0.0D;
++        if (y == -0.0D) y = 0.0D;
++        if (z == -0.0D) z = 0.0D;
++        return this;
++    }
++
++    /**
+      * Returns whether this vector is in an axis-aligned bounding box.
+      * <p>
+      * The minimum and maximum vectors given must be truly the minimum and
+@@ -355,6 +388,148 @@
+     }
+ 
+     /**
++     * Returns if a vector is normalized
++     *
++     * @return whether the vector is normalised
++     */
++    public boolean isNormalized() {
++        return Math.abs(this.lengthSquared() - 1) < getEpsilon();
++    }
++
++    /**
++     * Rotates the vector around the x axis.
++     * <p>
++     * This piece of math is based on the standard rotation matrix for vectors
++     * in three dimensional space. This matrix can be found here:
++     * <a href="https://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">Rotation
++     * Matrix</a>.
++     *
++     * @param angle the angle to rotate the vector about. This angle is passed
++     * in radians
++     * @return the same vector
++     */
++    public Vector rotateAroundX(double angle) {
++        double angleCos = Math.cos(angle);
++        double angleSin = Math.sin(angle);
++
++        double y = angleCos * getY() - angleSin * getZ();
++        double z = angleSin * getY() + angleCos * getZ();
++        return setY(y).setZ(z);
++    }
++
++    /**
++     * Rotates the vector around the y axis.
++     * <p>
++     * This piece of math is based on the standard rotation matrix for vectors
++     * in three dimensional space. This matrix can be found here:
++     * <a href="https://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">Rotation
++     * Matrix</a>.
++     *
++     * @param angle the angle to rotate the vector about. This angle is passed
++     * in radians
++     * @return the same vector
++     */
++    public Vector rotateAroundY(double angle) {
++        double angleCos = Math.cos(angle);
++        double angleSin = Math.sin(angle);
++
++        double x = angleCos * getX() + angleSin * getZ();
++        double z = -angleSin * getX() + angleCos * getZ();
++        return setX(x).setZ(z);
++    }
++
++    /**
++     * Rotates the vector around the z axis
++     * <p>
++     * This piece of math is based on the standard rotation matrix for vectors
++     * in three dimensional space. This matrix can be found here:
++     * <a href="https://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations">Rotation
++     * Matrix</a>.
++     *
++     * @param angle the angle to rotate the vector about. This angle is passed
++     * in radians
++     * @return the same vector
++     */
++    public Vector rotateAroundZ(double angle) {
++        double angleCos = Math.cos(angle);
++        double angleSin = Math.sin(angle);
++
++        double x = angleCos * getX() - angleSin * getY();
++        double y = angleSin * getX() + angleCos * getY();
++        return setX(x).setY(y);
++    }
++
++    /**
++     * Rotates the vector around a given arbitrary axis in 3 dimensional space.
++     *
++     * <p>
++     * Rotation will follow the general Right-Hand-Rule, which means rotation
++     * will be counterclockwise when the axis is pointing towards the observer.
++     * <p>
++     * This method will always make sure the provided axis is a unit vector, to
++     * not modify the length of the vector when rotating. If you are experienced
++     * with the scaling of a non-unit axis vector, you can use
++     * {@link Vector#rotateAroundNonUnitAxis(Vector, double)}.
++     *
++     * @param axis the axis to rotate the vector around. If the passed vector is
++     * not of length 1, it gets copied and normalized before using it for the
++     * rotation. Please use {@link Vector#normalize()} on the instance before
++     * passing it to this method
++     * @param angle the angle to rotate the vector around the axis
++     * @return the same vector
++     * @throws IllegalArgumentException if the provided axis vector instance is
++     * null
++     */
++    public Vector rotateAroundAxis(Vector axis, double angle) throws IllegalArgumentException {
++        Preconditions.checkArgument(axis != null, "The provided axis vector was null");
++
++        return rotateAroundNonUnitAxis(axis.isNormalized() ? axis : axis.clone().normalize(), angle);
++    }
++
++    /**
++     * Rotates the vector around a given arbitrary axis in 3 dimensional space.
++     *
++     * <p>
++     * Rotation will follow the general Right-Hand-Rule, which means rotation
++     * will be counterclockwise when the axis is pointing towards the observer.
++     * <p>
++     * Note that the vector length will change accordingly to the axis vector
++     * length. If the provided axis is not a unit vector, the rotated vector
++     * will not have its previous length. The scaled length of the resulting
++     * vector will be related to the axis vector. If you are not perfectly sure
++     * about the scaling of the vector, use
++     * {@link Vector#rotateAroundAxis(Vector, double)}
++     *
++     * @param axis the axis to rotate the vector around.
++     * @param angle the angle to rotate the vector around the axis
++     * @return the same vector
++     * @throws IllegalArgumentException if the provided axis vector instance is
++     * null
++     */
++    public Vector rotateAroundNonUnitAxis(Vector axis, double angle) throws IllegalArgumentException {
++        Preconditions.checkArgument(axis != null, "The provided axis vector was null");
++
++        double x = getX(), y = getY(), z = getZ();
++        double x2 = axis.getX(), y2 = axis.getY(), z2 = axis.getZ();
++
++        double cosTheta = Math.cos(angle);
++        double sinTheta = Math.sin(angle);
++        double dotProduct = this.dot(axis);
++
++        double xPrime = x2 * dotProduct * (1d - cosTheta)
++                + x * cosTheta
++                + (-z2 * y + y2 * z) * sinTheta;
++        double yPrime = y2 * dotProduct * (1d - cosTheta)
++                + y * cosTheta
++                + (z2 * x - x2 * z) * sinTheta;
++        double zPrime = z2 * dotProduct * (1d - cosTheta)
++                + z * cosTheta
++                + (-y2 * x + x2 * y) * sinTheta;
++
++        return setX(xPrime).setY(yPrime).setZ(zPrime);
++    }
++
++    /**
+      * Gets the X component.
+      *
+      * @return The X component.
+@@ -597,6 +772,17 @@
+     }
+ 
+     /**
++     * Check if each component of this Vector is finite.
++     *
++     * @throws IllegalArgumentException if any component is not finite
++     */
++    public void checkFinite() throws IllegalArgumentException {
++        NumberConversions.checkFinite(x, "x not finite");
++        NumberConversions.checkFinite(y, "y not finite");
++        NumberConversions.checkFinite(z, "z not finite");
++    }
++
++    /**
+      * Get the threshold used for equals().
+      *
+      * @return The epsilon.

--- a/src/main/java/io/github/crucible/eventfactory/PluginClassLoaderFactory.java
+++ b/src/main/java/io/github/crucible/eventfactory/PluginClassLoaderFactory.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.objectweb.asm.Opcodes.*;
 
 public class PluginClassLoaderFactory {
-    private static AtomicInteger IDs = new AtomicInteger();
+    private static final AtomicInteger IDs = new AtomicInteger();
     private static final HashMap<Method, Class<?>> cache = Maps.newHashMap();
     private static final String HANDLER_DESC = Type.getInternalName(IEventListener.class);
     private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Event.class));

--- a/src/main/java/org/bukkit/craftbukkit/v1_7_R4/CraftWorld.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_7_R4/CraftWorld.java
@@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.v1_7_R4;
 
 import cpw.mods.fml.common.registry.EntityRegistry;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.BlockSnapshot;
 import org.apache.commons.lang.Validate;
@@ -30,10 +31,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.messaging.StandardMessenger;
+import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public class CraftWorld implements World {
     //public static final int CUSTOM_DIMENSION_OFFSET = 10; // Cauldron - disabled
@@ -319,6 +323,11 @@ public class CraftWorld implements World {
         return isChunkLoaded(chunk.getX(), chunk.getZ());
     }
 
+    @Override
+    public boolean isChunkGenerated(int x, int z) {
+        return isChunkLoaded(x, z) || world.theChunkProviderServer.currentChunkProvider.chunkExists(x,z);
+    }
+
     public void loadChunk(Chunk chunk) {
         loadChunk(chunk.getX(), chunk.getZ());
         ((CraftChunk) getChunkAt(chunk.getX(), chunk.getZ())).getHandle().bukkitChunk = chunk;
@@ -328,18 +337,33 @@ public class CraftWorld implements World {
         return world;
     }
 
+    @Override
     public org.bukkit.entity.Item dropItem(Location loc, ItemStack item) {
+        return dropItem(loc, item, null);
+    }
+
+    @Override
+    public org.bukkit.entity.Item dropItem(Location loc, ItemStack item, Consumer<org.bukkit.entity.Item> function) {
         Validate.notNull(item, "Cannot drop a Null item.");
         Validate.isTrue(item.getTypeId() != 0, "Cannot drop AIR.");
         net.minecraft.entity.item.EntityItem entity = new net.minecraft.entity.item.EntityItem(world, loc.getX(), loc.getY(), loc.getZ(), CraftItemStack.asNMSCopy(item));
         entity.delayBeforeCanPickup = 10;
+        if (function != null) {
+            function.accept((org.bukkit.entity.Item) entity.getBukkitEntity());
+        }
         world.spawnEntityInWorld(entity);
         // TODO this is inconsistent with how Entity.getBukkitEntity() works.
         // However, this entity is not at the moment backed by a server entity class so it may be left.
         return new CraftItem(world.getServer(), entity);
     }
 
+    @Override
     public org.bukkit.entity.Item dropItemNaturally(Location loc, ItemStack item) {
+        return dropItemNaturally(loc, item, null);
+    }
+
+    @Override
+    public org.bukkit.entity.Item dropItemNaturally(Location loc, ItemStack item, Consumer<Item> function) {
         double xs = world.rand.nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
         double ys = world.rand.nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
         double zs = world.rand.nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
@@ -347,7 +371,7 @@ public class CraftWorld implements World {
         loc.setX(loc.getX() + xs);
         loc.setY(loc.getY() + ys);
         loc.setZ(loc.getZ() + zs);
-        return dropItem(loc, item);
+        return dropItem(loc, item, function);
     }
 
     public Arrow spawnArrow(Location loc, Vector velocity, float speed, float spread) {
@@ -794,6 +818,43 @@ public class CraftWorld implements World {
         }
 
         return list;
+    }
+
+    @Override
+    public Collection<Entity> getNearbyEntities(Location location, double x, double y, double z) {
+        return this.getNearbyEntities(location, x, y, z, null);
+    }
+
+    @Override
+    public Collection<Entity> getNearbyEntities(Location location, double x, double y, double z, Predicate<Entity> filter) {
+        org.apache.commons.lang3.Validate.notNull(location, "Location is null!");
+        org.apache.commons.lang3.Validate.isTrue(this.equals(location.getWorld()), "Location is from different world!");
+
+        BoundingBox aabb = BoundingBox.of(location, x, y, z);
+        return this.getNearbyEntities(aabb, filter);
+    }
+
+    @Override
+    public Collection<Entity> getNearbyEntities(BoundingBox boundingBox) {
+        return this.getNearbyEntities(boundingBox, null);
+    }
+
+    @Override
+    public Collection<Entity> getNearbyEntities(BoundingBox boundingBox, Predicate<Entity> filter) {
+        org.apache.commons.lang3.Validate.notNull(boundingBox, "Bounding box is null!");
+
+        AxisAlignedBB bb = AxisAlignedBB.getBoundingBox(boundingBox.getMinX(), boundingBox.getMinY(), boundingBox.getMinZ(), boundingBox.getMaxX(), boundingBox.getMaxY(), boundingBox.getMaxZ());
+        List<net.minecraft.entity.Entity> entityList = getHandle().selectEntitiesWithinAABB(net.minecraft.entity.Entity.class, bb, null);
+        List<Entity> bukkitEntityList = new ArrayList<org.bukkit.entity.Entity>(entityList.size());
+
+        for (net.minecraft.entity.Entity entity : entityList) {
+            Entity bukkitEntity = entity.getBukkitEntity();
+            if (filter == null || filter.test(bukkitEntity)) {
+                bukkitEntityList.add(bukkitEntity);
+            }
+        }
+
+        return bukkitEntityList;
     }
 
     public void save() {


### PR DESCRIPTION
On 1.7.10 is not possible to 'getNearbyEntities' without having an entity as reference. That sucks.

Backport some part of the world-api from bukkit 1.18.8 (after this one Vector.class changed, so lets stay with that version)


Seems to work pretty well, still doing some tests.