### PR TITLE
Add HTTP timeouts and retries for Gradle dependency downloads

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,9 @@
 org.gradle.daemon=false
 file.encoding=UTF-8
 org.gradle.jvmargs=-Xmn4G
+# Fail-fast HTTP timeouts + bounded retries so a stalled CDN mirror (Cloudflare) retries
+# instead of hanging the build indefinitely.
+systemProp.org.gradle.internal.http.socketTimeout=60000
+systemProp.org.gradle.internal.http.connectionTimeout=30000
+systemProp.org.gradle.internal.repository.max.tentatives=10
+systemProp.org.gradle.internal.repository.initial.backoff=1000


### PR DESCRIPTION
## Build resilience: HTTP timeouts + retries for Gradle dependency downloads

Adds bounded socket/connection timeouts and a retry budget to `gradle.properties` so a stalled dependency mirror fails fast and retries, instead of hanging the build indefinitely.

Build-infra only — no runtime/behaviour change.