### PR TITLE
Fix RCON can't execute mod command

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_7_R4/command/CraftSimpleCommandMap.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_7_R4/command/CraftSimpleCommandMap.java
@@ -2,6 +2,7 @@ package org.bukkit.craftbukkit.v1_7_R4.command;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.network.rcon.RConConsoleSource;
 import org.bukkit.Server;
 import org.bukkit.command.*;
 import org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer;
@@ -45,8 +46,11 @@ public class CraftSimpleCommandMap extends SimpleCommandMap {
                 }
                 if (sender instanceof ConsoleCommandSender) {
                     FMLCommonHandler.instance().getMinecraftServerInstance().getCommandManager().executeCommand(this.vanillaConsoleSender, commandLine);
-                } else
+                } else if (sender instanceof RemoteConsoleCommandSender) {
+                    FMLCommonHandler.instance().getMinecraftServerInstance().getCommandManager().executeCommand(RConConsoleSource.instance, commandLine);
+                } else if (sender instanceof CraftPlayer) {
                     FMLCommonHandler.instance().getMinecraftServerInstance().getCommandManager().executeCommand(((CraftPlayer) sender).getHandle(), commandLine);
+                }
             } else {
                 // Cauldron end
                 // Note: we don't return the result of target.execute as thats success / failure, we return handled (true) or not handled (false)


### PR DESCRIPTION
I got an error when trying to execute a forge mod commands by RCON. This is simply a statement missing in CraftSimpleCommandMap.
```
[11:25:08] [Server thread/WARN] [Minecraft/]: Unexpected exception while parsing console command "gt global_energy_display Developer"
org.bukkit.command.CommandException: Unhandled exception executing 'gt global_energy_display MIAOW246' in org.bukkit.craftbukkit.v1_7_R4.command.ModCustomCommand(gregtech)
	at Launch//org.bukkit.craftbukkit.v1_7_R4.command.CraftSimpleCommandMap.dispatch(CraftSimpleCommandMap.java:58) ~[CraftSimpleCommandMap.class:1.7.10-staging-4e42e0d]
	at Launch//org.bukkit.craftbukkit.v1_7_R4.CraftServer.dispatchVanillaCommand(CraftServer.java:730) ~[CraftServer.class:1.7.10-staging-4e42e0d]
	at Launch//org.bukkit.craftbukkit.v1_7_R4.CraftServer.dispatchServerCommand(CraftServer.java:697) [CraftServer.class:1.7.10-staging-4e42e0d]
	at Launch//net.minecraft.server.MinecraftServer$6.evaluate(MinecraftServer.java:1835) [lm.class:?]
	at Launch//net.minecraft.server.MinecraftServer$6.evaluate(MinecraftServer.java:1825) [lm.class:?]
	at Launch//org.bukkit.craftbukkit.v1_7_R4.util.Waitable.run(Waitable.java:19) [Waitable.class:1.7.10-staging-4e42e0d]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:918) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:414) [lt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:848) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:698) [MinecraftServer.class:?]
	at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]
Caused by: java.lang.ClassCastException: class org.bukkit.craftbukkit.v1_7_R4.command.CraftRemoteConsoleCommandSender cannot be cast to class org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer (org.bukkit.craftbukkit.v1_7_R4.command.CraftRemoteConsoleCommandSender and org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer are in unnamed module of loader 'Launch' @24b61d59)
	at Launch//org.bukkit.craftbukkit.v1_7_R4.command.CraftSimpleCommandMap.dispatch(CraftSimpleCommandMap.java:49) ~[CraftSimpleCommandMap.class:1.7.10-staging-4e42e0d]
	... 10 more
```