### PR TITLE
 Optimize world save logic

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -412,12 +412,6 @@
  
 -                    try
 +                    worldserver.saveAllChunks(true, (IProgressUpdate) null);
-+                    if (!p_71267_1_)
-+                    {
-+                        worldserver.timings.worldIOFlush.startTiming();
-+                        worldserver.flush();
-+                        worldserver.timings.worldIOFlush.stopTiming();
-+                    }
 +                    WorldSaveEvent event = new WorldSaveEvent(worldserver.getWorld());
 +                    this.server.getPluginManager().callEvent(event);
 +                    // Cauldron start - save world configs

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -412,9 +412,12 @@
  
 -                    try
 +                    worldserver.saveAllChunks(true, (IProgressUpdate) null);
-+                    worldserver.timings.worldIOFlush.startTiming();
-+                    worldserver.flush();
-+                    worldserver.timings.worldIOFlush.stopTiming();
++                    if (!p_71267_1_)
++                    {
++                        worldserver.timings.worldIOFlush.startTiming();
++                        worldserver.flush();
++                        worldserver.timings.worldIOFlush.stopTiming();
++                    }
 +                    WorldSaveEvent event = new WorldSaveEvent(worldserver.getWorld());
 +                    this.server.getPluginManager().callEvent(event);
 +                    // Cauldron start - save world configs

--- a/patches/net/minecraft/world/chunk/storage/RegionFileCache.java.patch
+++ b/patches/net/minecraft/world/chunk/storage/RegionFileCache.java.patch
@@ -64,7 +64,7 @@
 -            {
 -                clearRegionFileReferences();
 -            }
-+			if (REGIONS_BY_FILE.size() >= 256)
++			if (REGIONS_BY_FILE.size() >= CrucibleConfigs.configs.crucible_chunkCacheSize)
 +			{
 +				deleteOldestReference();
 +			}
@@ -91,16 +91,7 @@
 +	// This is a key part of ensuring that the chunk existence thread can complete its necessary tasks
 +	public static synchronized void deleteOldestReference()
 +	{
-+		long oldest = System.currentTimeMillis();
-+		File toJunk = null;
-+		for (Map.Entry<File,RegionFile> entry :REGIONS_BY_FILE.entrySet())
-+		{
-+			if(entry.getKey().lastModified() < oldest)
-+			{
-+				oldest = entry.getKey().lastModified();
-+				toJunk = entry.getKey();
-+			}
-+		}
++		File toJunk = REGIONS_BY_FILE.isEmpty() ? null : REGIONS_BY_FILE.keySet().iterator().next();
 +		if(toJunk != null)
 +		{
 +			try
@@ -178,9 +169,9 @@
 +		}
 +		else if (file1.exists() && file2.exists())
 +		{
-+			if (REGIONS_BY_FILE.size() >= 256)
++			if (REGIONS_BY_FILE.size() >= CrucibleConfigs.configs.crucible_chunkCacheSize)
 +			{
-+				clearRegionFileReferences();
++				deleteOldestReference();
 +			}
 +
 +			RegionFile regionfile1 = new RegionFile(file2);


### PR DESCRIPTION
My GTNH Crucible server has suffered from periodic lag spikes for a long time. Spark shows this may mainly casued by the autosave's `flush()` call. In default it will run a global `waitForFinish()` and closes every cached region file every 900tick. This will result in significant pause on server-thread when the world is larger then 5GB. Skipping **the flush** on autosave is safe since the autosave still writes chunks to disk every 900 tick.                                                                                                                                                                                                                                                                                                                       
 I also notice that the region-file cache size was hardcoded at 256 instead of reading `crucible_chunkCacheSize`. Region-file eviction is now O(1) and use config's cache size.