### PR TITLE
Stop reporting tile entities the world already dropped

### DIFF
--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -184,17 +184,27 @@
              {
                  ChunkCoordIntPair chunkcoordintpair = (ChunkCoordIntPair)iterator1.next();
  
-@@ -253,8 +357,7 @@
+@@ -253,8 +357,17 @@
                          if (chunk.func_150802_k())
                          {
                              arraylist.add(chunk);
 -                            arraylist1.addAll(((WorldServer)this.worldObj).func_147486_a(chunkcoordintpair.chunkXPos * 16, 0, chunkcoordintpair.chunkZPos * 16, chunkcoordintpair.chunkXPos * 16 + 15, 256, chunkcoordintpair.chunkZPos * 16 + 15));
 -                            //BugFix: 16 makes it load an extra chunk, which isn't associated with a player, which makes it not unload unless a player walks near it.
-+                            arraylist1.addAll(chunk.chunkTileEntityMap.values()); // CraftBukkit - Get tile entities directly from the chunk instead of the world
++
++                            // CraftBukkit - Get tile entities directly from the chunk instead of the world
++                            for (Object te : chunk.chunkTileEntityMap.values())
++                            {
++                                // The chunk map keeps invalidated entries until the world tick sweeps them.
++                                if (!((TileEntity)te).isInvalid())
++                                {
++                                    arraylist1.add(te);
++                                }
++                            }
++
                              iterator1.remove();
                          }
                      }
-@@ -297,9 +400,16 @@
+@@ -297,9 +410,16 @@
              for (int i = 0; i < this.inventory.getSizeInventory(); ++i)
              {
                  ItemStack itemstack = this.inventory.getStackInSlot(i);
@@ -213,7 +223,7 @@
                      Packet packet = ((ItemMapBase)itemstack.getItem()).func_150911_c(itemstack, this.worldObj, this);
  
                      if (packet != null)
-@@ -309,9 +419,10 @@
+@@ -309,9 +429,10 @@
                  }
              }
  
@@ -225,7 +235,7 @@
                  this.lastHealth = this.getHealth();
                  this.lastFoodLevel = this.foodStats.getFoodLevel();
                  this.wasHungry = this.foodStats.getSaturationLevel() == 0.0F;
-@@ -320,16 +431,18 @@
+@@ -320,16 +441,18 @@
              if (this.getHealth() + this.getAbsorptionAmount() != this.field_130068_bO)
              {
                  this.field_130068_bO = this.getHealth() + this.getAbsorptionAmount();
@@ -251,7 +261,7 @@
              if (this.experienceTotal != this.lastExperience)
              {
                  this.lastExperience = this.experienceTotal;
-@@ -340,6 +453,20 @@
+@@ -340,6 +463,20 @@
              {
                  this.func_147098_j();
              }
@@ -272,7 +282,7 @@
          }
          catch (Throwable throwable)
          {
-@@ -400,36 +527,85 @@
+@@ -400,36 +537,85 @@
          }
      }
  
@@ -367,7 +377,7 @@
              score.func_96648_a();
          }
  
-@@ -495,7 +671,8 @@
+@@ -495,7 +681,8 @@
  
      public boolean canAttackPlayer(EntityPlayer p_96122_1_)
      {
@@ -377,7 +387,7 @@
      }
  
      public void travelToDimension(int p_71027_1_)
-@@ -526,7 +703,10 @@
+@@ -526,7 +713,10 @@
                  this.triggerAchievement(AchievementList.portal);
              }
  
@@ -389,7 +399,7 @@
              this.lastExperience = -1;
              this.lastHealth = -1.0F;
              this.lastFoodLevel = -1;
-@@ -569,6 +749,11 @@
+@@ -569,6 +759,11 @@
  
      public void wakeUpPlayer(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -401,7 +411,7 @@
          if (this.isPlayerSleeping())
          {
              this.getServerForPlayer().getEntityTracker().func_151248_b(this, new S0BPacketAnimation(this, 2));
-@@ -584,11 +769,27 @@
+@@ -584,11 +779,27 @@
  
      public void mountEntity(Entity p_70078_1_)
      {
@@ -432,7 +442,7 @@
      protected void updateFallState(double p_70064_1_, boolean p_70064_3_) {}
  
      public void handleFalling(double p_71122_1_, boolean p_71122_3_)
-@@ -610,29 +811,64 @@
+@@ -610,29 +821,64 @@
          this.currentWindowId = this.currentWindowId % 100 + 1;
      }
  
@@ -500,7 +510,7 @@
          this.openContainer.windowId = this.currentWindowId;
          this.openContainer.addCraftingToCrafters(this);
      }
-@@ -644,71 +880,150 @@
+@@ -644,71 +890,150 @@
              this.closeScreen();
          }
  
@@ -659,7 +669,7 @@
          this.openContainer.windowId = this.currentWindowId;
          this.openContainer.addCraftingToCrafters(this);
          InventoryMerchant inventorymerchant = ((ContainerMerchant)this.openContainer).getMerchantInventory();
-@@ -725,7 +1040,7 @@
+@@ -725,7 +1050,7 @@
                  merchantrecipelist.func_151391_a(packetbuffer);
                  this.playerNetServerHandler.sendPacket(new S3FPacketCustomPayload("MC|TrList", packetbuffer));
              }
@@ -668,7 +678,7 @@
              {
                  logger.error("Couldn\'t send trade list", ioexception);
              }
-@@ -738,6 +1053,17 @@
+@@ -738,6 +1063,17 @@
  
      public void displayGUIHorse(EntityHorse p_110298_1_, IInventory p_110298_2_)
      {
@@ -686,7 +696,7 @@
          if (this.openContainer != this.inventoryContainer)
          {
              this.closeScreen();
-@@ -745,7 +1071,7 @@
+@@ -745,7 +1081,7 @@
  
          this.getNextWindowId();
          this.playerNetServerHandler.sendPacket(new S2DPacketOpenWindow(this.currentWindowId, 11, p_110298_2_.getInventoryName(), p_110298_2_.getSizeInventory(), p_110298_2_.hasCustomInventoryName(), p_110298_1_.getEntityId()));
@@ -695,7 +705,7 @@
          this.openContainer.windowId = this.currentWindowId;
          this.openContainer.addCraftingToCrafters(this);
      }
-@@ -770,6 +1096,15 @@
+@@ -770,6 +1106,15 @@
      {
          this.playerNetServerHandler.sendPacket(new S30PacketWindowItems(p_71110_1_.windowId, p_71110_2_));
          this.playerNetServerHandler.sendPacket(new S2FPacketSetSlot(-1, -1, this.inventory.getItemStack()));
@@ -711,7 +721,7 @@
      }
  
      public void sendProgressBarUpdate(Container p_71112_1_, int p_71112_2_, int p_71112_3_)
-@@ -779,6 +1114,7 @@
+@@ -779,6 +1124,7 @@
  
      public void closeScreen()
      {
@@ -719,7 +729,7 @@
          this.playerNetServerHandler.sendPacket(new S2EPacketCloseWindow(this.openContainer.windowId));
          this.closeContainer();
      }
-@@ -853,8 +1189,19 @@
+@@ -853,8 +1199,19 @@
      public void setPlayerHealthUpdated()
      {
          this.lastHealth = -1.0E8F;
@@ -739,7 +749,7 @@
      public void addChatComponentMessage(IChatComponent p_146105_1_)
      {
          this.playerNetServerHandler.sendPacket(new S02PacketChat(p_146105_1_));
-@@ -882,7 +1229,24 @@
+@@ -882,7 +1239,24 @@
          this.lastExperience = -1;
          this.lastHealth = -1.0F;
          this.lastFoodLevel = -1;
@@ -764,7 +774,7 @@
      }
  
      protected void onNewPotionEffect(PotionEffect p_70670_1_)
-@@ -1037,6 +1401,114 @@
+@@ -1037,6 +1411,114 @@
          return this.field_143005_bX;
      }
  

--- a/patches/net/minecraft/world/WorldServer.java.patch
+++ b/patches/net/minecraft/world/WorldServer.java.patch
@@ -574,16 +574,17 @@
          return this.theChunkProviderServer;
      }
  
-@@ -659,29 +914,31 @@
+@@ -659,29 +914,38 @@
      {
          ArrayList arraylist = new ArrayList();
  
 -        for(int x = (p_147486_1_ >> 4); x <= (p_147486_4_ >> 4); x++)
 +        // CraftBukkit start - Get tile entities from chunks instead of world
-+        for (int chunkX = (p_147486_1_ >> 4); chunkX <= ((p_147486_4_ - 1) >> 4); chunkX++)
++        // Crucible - inclusive maximum corner, the convention Forge mods compile against
++        for (int chunkX = (p_147486_1_ >> 4); chunkX <= (p_147486_4_ >> 4); chunkX++)
          {
 -            for(int z = (p_147486_3_ >> 4); z <= (p_147486_6_ >> 4); z++)
-+            for (int chunkZ = (p_147486_3_ >> 4); chunkZ <= ((p_147486_6_ - 1) >> 4); chunkZ++)
++            for (int chunkZ = (p_147486_3_ >> 4); chunkZ <= (p_147486_6_ >> 4); chunkZ++)
              {
 -                Chunk chunk = getChunkFromChunkCoords(x, z);
 -                if (chunk != null)
@@ -599,8 +600,8 @@
 +                {
 +                    TileEntity tileentity = (TileEntity) te;
 +
-+                    if ((tileentity.xCoord >= p_147486_1_) && (tileentity.yCoord >= p_147486_2_) && (tileentity.zCoord >= p_147486_3_)
-+                            && (tileentity.xCoord < p_147486_4_) && (tileentity.yCoord < p_147486_5_) && (tileentity.zCoord < p_147486_6_))
++                    // The chunk map keeps invalidated entries until the world tick sweeps them.
++                    if (tileentity.isInvalid())
                      {
 -                        TileEntity entity = (TileEntity)obj;
 -                        if (!entity.isInvalid())
@@ -611,8 +612,14 @@
 -                                arraylist.add(entity);
 -                            }
 -                        }
-+                        arraylist.add(tileentity);
++                        continue;
                      }
++
++                    if ((tileentity.xCoord >= p_147486_1_) && (tileentity.yCoord >= p_147486_2_) && (tileentity.zCoord >= p_147486_3_)
++                            && (tileentity.xCoord <= p_147486_4_) && (tileentity.yCoord <= p_147486_5_) && (tileentity.zCoord <= p_147486_6_))
++                    {
++                        arraylist.add(tileentity);
++                    }
                  }
              }
          }
@@ -621,7 +628,7 @@
          return arraylist;
      }
  
-@@ -704,7 +961,7 @@
+@@ -704,7 +968,7 @@
  
          if (this.pendingTickListEntriesHashSet == null)
          {
@@ -630,7 +637,7 @@
          }
  
          if (this.pendingTickListEntriesTreeSet == null)
-@@ -733,7 +990,28 @@
+@@ -733,7 +997,28 @@
              int i = 0;
              int j = this.provider.getAverageGroundLevel();
              int k = 0;
@@ -659,7 +666,7 @@
              if (chunkposition != null)
              {
                  i = chunkposition.chunkPosX;
-@@ -799,14 +1077,18 @@
+@@ -799,14 +1084,18 @@
                  p_73044_2_.displayProgressMessage("Saving level");
              }
  
@@ -678,7 +685,7 @@
              MinecraftForge.EVENT_BUS.post(new WorldEvent.Save(this));
              ArrayList arraylist = Lists.newArrayList(this.theChunkProviderServer.func_152380_a());
              Iterator iterator = arraylist.iterator();
-@@ -876,6 +1158,20 @@
+@@ -876,6 +1165,20 @@
  
      public boolean addWeatherEffect(Entity p_72942_1_)
      {
@@ -699,7 +706,7 @@
          if (super.addWeatherEffect(p_72942_1_))
          {
              this.mcServer.getConfigurationManager().sendToAllNear(p_72942_1_.posX, p_72942_1_.posY, p_72942_1_.posZ, 512.0D, this.provider.dimensionId, new S2CPacketSpawnGlobalEntity(p_72942_1_));
-@@ -894,13 +1190,24 @@
+@@ -894,13 +1197,24 @@
  
      public Explosion newExplosion(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
@@ -725,7 +732,7 @@
          if (!p_72885_10_)
          {
              explosion.affectedBlockPositions.clear();
-@@ -977,7 +1284,8 @@
+@@ -977,7 +1291,8 @@
      {
          boolean flag = this.isRaining();
          super.updateWeather();
@@ -735,7 +742,7 @@
          if (this.prevRainingStrength != this.rainingStrength)
          {
              this.mcServer.getConfigurationManager().sendPacketToAllPlayersInDimension(new S2BPacketChangeGameState(7, this.rainingStrength), this.provider.dimensionId);
-@@ -987,11 +1295,9 @@
+@@ -987,11 +1302,9 @@
          {
              this.mcServer.getConfigurationManager().sendPacketToAllPlayersInDimension(new S2BPacketChangeGameState(8, this.thunderingStrength), this.provider.dimensionId);
          }
@@ -749,7 +756,7 @@
          if (flag != this.isRaining())
          {
              if (flag)
-@@ -1006,6 +1312,33 @@
+@@ -1006,6 +1319,33 @@
              this.mcServer.getConfigurationManager().sendPacketToAllPlayersInDimension(new S2BPacketChangeGameState(7, this.rainingStrength), this.provider.dimensionId);
              this.mcServer.getConfigurationManager().sendPacketToAllPlayersInDimension(new S2BPacketChangeGameState(8, this.thunderingStrength), this.provider.dimensionId);
          }
@@ -783,7 +790,7 @@
      }
  
      protected int func_152379_p()
-@@ -1069,4 +1402,53 @@
+@@ -1069,4 +1409,53 @@
                  this();
              }
          }


### PR DESCRIPTION
## Problem

Vanilla read the world's own tile entity list, which its tick sweeps clean, so neither of these
readers could return a dead entry or miss a live one. Forge changed the source to
`Chunk.chunkTileEntityMap` for the chunk-scoped lookup and compensated on both counts: an inclusive
maximum corner, and a `!isInvalid()` guard backed by a `Chunk.removeInvalidTileEntity` it had to
add, called only from `World.updateEntities`. Cauldron re-ported CraftBukkit's version over Forge's
and kept the new data source without either compensation. That is what this tree inherited — traced
to the initial Thermos import, never a deliberate decision here.

Both losses are real:

- **Bounds.** `WorldServer.func_147486_a` treats the maximum corner as exclusive while every caller
  compiled against Forge passes an inclusive one. A caller asking for a whole chunk silently misses
  the last block row and column — 31 of 256 columns. The method has no caller left in this tree,
  but mods call it.
- **Validity.** The sweep that reconciles the chunk map is the Spigot time-boxed loop, with a
  rolling cursor and a `max-tick-time.tile` budget, so under load it does not finish in a tick and
  an invalidated entry stays visible for an unbounded number of them.

## Change

`func_147486_a` takes the maximum corner as inclusive again and skips invalidated entries.
`EntityPlayerMP` does the same filtering where it collects a chunk's tile entities to send — it
feeds them straight to `getDescriptionPacket`, which is mod code running on an object the world
considers dead.

## Verification

A HeadlessMC Forge 1.7.10 client joined a modded Crucible (15 mods, CustomNPC-Plus among them) and
streamed chunks for real. 60 CustomNPCs blocks that carry a tile entity were placed around the
player — `npcWaypoint`, `npcBorder`, `npcLampUnlit`, `npcCarpentyBench`, `npcChair`, `npcTombstone`,
`npcBarrel`, `npcRedstoneBlock`, `npcCampfireUnlit`, `npcCandleUnlit`, `npcSign` and others, drawn
at random from the 31 registered types.

Each was then invalidated the way a mod does on a state change: `invalidate()` only, block and chunk
map entry left alone. The chunks were re-queued in the same breath, so the send happens while the
dead entries are still in `chunkTileEntityMap` — the exact window the guard exists for. The filter
was toggled at runtime between the two runs, so both sides saw the same server, the same world and
the same kind of tile entity:

```
fixed     [ChunkSend] chunks=49 packets=10 tiles=0  skippedInvalid=62 sentInvalid=0
pre-fix   [ChunkSend] chunks=50 packets=10 tiles=46 skippedInvalid=0  sentInvalid=46
```

Without the guard, 46 tile entities the world had already dropped had `getDescriptionPacket()`
called on them and were shipped to the client. With it, none were: `tiles=0`, and the 62 dead
entries were skipped. None of the CustomNPCs types threw on the call, so the harm here is stale
state reaching the client rather than a crash — but the packet is built from mod code running on an
invalidated object, and what that returns is the mod's business, not something this path can assume.

The bounds half has no runtime coverage: nothing in this tree calls `func_147486_a` any more, so
that change is argued from the Forge sources it realigns with, not demonstrated by a test.
