### PR TITLE
Make the chunk packet deflate level configurable

### DIFF
--- a/patches/net/minecraft/network/play/server/S26PacketMapChunkBulk.java.patch
+++ b/patches/net/minecraft/network/play/server/S26PacketMapChunkBulk.java.patch
@@ -1,6 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/network/play/server/S26PacketMapChunkBulk.java
 +++ ../src-work/minecraft/net/minecraft/network/play/server/S26PacketMapChunkBulk.java
-@@ -24,10 +24,18 @@
+@@ -4,7 +4,6 @@
+ import cpw.mods.fml.relauncher.SideOnly;
+ import java.io.IOException;
+ import java.util.List;
+-import java.util.concurrent.Semaphore;
+ import java.util.zip.DataFormatException;
+ import java.util.zip.Deflater;
+ import java.util.zip.Inflater;
+@@ -14,6 +13,8 @@
+ import net.minecraft.network.play.INetHandlerPlayClient;
+ import net.minecraft.world.chunk.Chunk;
+ 
++import io.github.crucible.CrucibleConfigs;
++
+ public class S26PacketMapChunkBulk extends Packet
+ {
+     private int[] field_149266_a;
+@@ -24,10 +25,19 @@
      private byte[][] field_149260_f;
      private int field_149261_g;
      private boolean field_149267_h;
@@ -15,15 +32,16 @@
 +        @Override
 +        protected Deflater initialValue()
 +        {
-+            // Don't use higher compression level, slows things down too much
-+            return new Deflater(4); // Spigot 6 -> 4
++            // Crucible - read once per thread: the level is a restart-time decision, not a per
++            // packet one, and reapplying it on a pooled deflater costs a wasted deflate() call
++            return new Deflater(clampCompressionLevel(CrucibleConfigs.configs.crucible_optimization_chunkCompressionLevel));
 +        }
 +    };
 +    // CraftBukkit end
  
      public S26PacketMapChunkBulk() {}
  
-@@ -46,6 +54,15 @@
+@@ -46,6 +56,15 @@
          {
              Chunk chunk = (Chunk)p_i45197_1_.get(k);
              S21PacketChunkData.Extracted extracted = S21PacketChunkData.func_149269_a(chunk, true, 65535);
@@ -39,65 +57,100 @@
              j += extracted.field_150282_a.length;
              this.field_149266_a[k] = chunk.xPosition;
              this.field_149264_b[k] = chunk.zPosition;
-@@ -53,34 +70,36 @@
+@@ -53,35 +72,75 @@
              this.field_149262_d[k] = extracted.field_150281_c;
              this.field_149260_f[k] = extracted.field_150282_a;
          }
 -        this.deflateGate = new Semaphore(1);
 -        maxLen = j;
--    }
--
--    private void deflate()
--    {
--        byte[] data = new byte[maxLen];
--        int offset = 0;
--        for (int x = 0; x < field_149260_f.length; x++)
--        {
--            System.arraycopy(field_149260_f[x], 0, data, offset, field_149260_f[x].length);
--            offset += field_149260_f[x].length;
--        }
 +        /* CraftBukkit start - Moved to compress()
-         Deflater deflater = new Deflater(-1);
- 
--        try
--        {
--            deflater.setInput(data, 0, data.length);
++        Deflater deflater = new Deflater(-1);
++
 +        try {
 +            deflater.setInput(buildBuffer, 0, j);
-             deflater.finish();
--            byte[] deflated = new byte[data.length];
--            this.field_149261_g = deflater.deflate(deflated);
--            this.field_149263_e = deflated;
++            deflater.finish();
 +            this.buffer = new byte[j];
 +            this.size = deflater.deflate(this.buffer);
 +        } finally {
 +            deflater.end();
-         }
--        finally
++        }
 +        */
-+    }
-+
+     }
+ 
+-    private void deflate()
 +    // Add compression method
 +    public void compress()
-+    {
+     {
+-        byte[] data = new byte[maxLen];
+-        int offset = 0;
+-        for (int x = 0; x < field_149260_f.length; x++)
 +        if (this.field_149263_e != null)
          {
--            deflater.end();
+-            System.arraycopy(field_149260_f[x], 0, data, offset, field_149260_f[x].length);
+-            offset += field_149260_f[x].length;
 +            return;
          }
-+
+-        Deflater deflater = new Deflater(-1);
+ 
+-        try
 +        Deflater deflater = localDeflater.get();
 +        deflater.reset();
 +        deflater.setInput(this.field_149268_i);
 +        deflater.finish();
-+        this.field_149263_e = new byte[this.field_149268_i.length + 100];
++        this.field_149263_e = new byte[deflateBound(this.field_149268_i.length)];
 +        this.field_149261_g = deflater.deflate(this.field_149263_e);
++
++        if (!deflater.finished())
+         {
+-            deflater.setInput(data, 0, data.length);
+-            deflater.finish();
+-            byte[] deflated = new byte[data.length];
+-            this.field_149261_g = deflater.deflate(deflated);
+-            this.field_149263_e = deflated;
++            // deflate() reports a buffer that is too small by writing what fits and returning, so
++            // without this the packet would carry a truncated stream and the client would inflate
++            // it into empty chunks without an error on either side.
++            throw new IllegalStateException("Chunk deflate stopped short: wrote " + this.field_149261_g
++                    + " of a " + this.field_149263_e.length + " byte buffer for "
++                    + this.field_149268_i.length + " input bytes");
+         }
+-        finally
++    }
++
++    // Crucible start
++    // new Deflater accepts -1..9 and throws outside it, so a typo in the config must not become an
++    // exception on the netty thread. -1 is zlib's own default level rather than a value under the
++    // floor, so it passes through: clamping it to NO_COMPRESSION would ship chunks uncompressed.
++    private static int clampCompressionLevel(int level)
++    {
++        if (level == Deflater.DEFAULT_COMPRESSION)
+         {
+-            deflater.end();
++            return level;
+         }
++
++        if (level < Deflater.NO_COMPRESSION)
++        {
++            return Deflater.NO_COMPRESSION;
++        }
++
++        return level > Deflater.BEST_COMPRESSION ? Deflater.BEST_COMPRESSION : level;
      }
-+    // CraftBukkit end
  
++    // zlib's own compressBound. At a low level deflate stores rather than compresses and the output
++    // grows past the input; deflate() would then quietly stop short and ship a truncated stream.
++    private static int deflateBound(int length)
++    {
++        return length + (length >> 12) + (length >> 14) + (length >> 25) + 13;
++    }
++
++    // Crucible end
++    // CraftBukkit end
++
      public static int func_149258_c()
      {
-@@ -155,16 +174,7 @@
+         return 5;
+@@ -155,16 +214,7 @@
  
      public void writePacketData(PacketBuffer p_148840_1_) throws IOException
      {

--- a/src/main/java/io/github/crucible/CrucibleConfigs.java
+++ b/src/main/java/io/github/crucible/CrucibleConfigs.java
@@ -149,6 +149,19 @@ public class CrucibleConfigs extends YamlConfig {
             "changes how many of those a tick may send. Keep it at 50 or below, lower with many players."})
     public int crucible_optimization_maxChunkSendsPerTick = 5;
 
+    @Comments({"Deflate level for the bulk packets that stream chunks to players, from 0 to 9, or",
+            "-1 for zlib's own default. Single chunk update packets keep a fixed level of 4.",
+            "0 does not compress at all, 1 is the fastest real compression, 9 the smallest output.",
+            "The cost is CPU on the netty threads and the benefit is bandwidth, so the useful answer",
+            "depends on which of the two your host runs out of first. Measured on real chunk traffic,",
+            "going above 4 is close to worthless - level 9 buys 10% fewer bytes for 14x the CPU - while",
+            "2 gives back 45% of the CPU for 28% more bytes, which is why it is the default.",
+            "At 0 a packet does not shrink, and one carrying more than 12 full chunks outgrows the",
+            "2MB protocol frame and disconnects the player. A packet holds the smaller of",
+            "'max-bulk-chunks' (spigot.yml) and the setting above, so 0 is only safe while both are.",
+            "Only read when a network thread starts compressing, so a change needs a restart."})
+    public int crucible_optimization_chunkCompressionLevel = 2;
+
     @Comment("Log Material injections.")
     public boolean crucible_logging_logMaterialInjection = false;
 


### PR DESCRIPTION
> Stacks on the other two: this branch merges `feature/fast-chunk-send` and
> `fix/tile-entities-in-range`, so until those land the diff here shows their commits too.
> Only the last commit is new work.

## Problem

The deflate level for chunk packets has been hardcoded since Spigot lowered it from 6 to 4, with a
comment saying a higher one slows things down too much and nothing saying what it costs to go lower.
It is a straight CPU-for-bandwidth trade made on the netty threads, and which of the two is scarce
is a property of the host, not of the server software.

## Change

`crucible.optimization.chunkCompressionLevel` sets the level, and the default moves from 4 to 2.
The level is read when a netty thread builds its pooled deflater, so editing it takes effect on the
next restart — the deflater is not reconfigured per packet.

The output buffer is also sized with zlib's `compressBound` instead of `input + 100`. Low levels are
reachable now, and at level 0 deflate stores rather than compresses, so its output is larger than
its input; `deflate()` would handle a short buffer by writing what fits and returning quietly, and
the packet would ship a truncated stream with no error anywhere. Out-of-range config values are
clamped rather than thrown, since the call site is the packet encoder and an exception there kills
the connection instead of logging.

## Evidence

Every level compressing the **identical payload**, so the comparison is over the same bytes rather
than two different flights over the world. Both runs are real packets written to the socket for a
HeadlessMC Forge 1.7.10 client, compressed on the netty threads by `writePacketData`.

### Vanilla world — 89 packets, 441 chunks, 21,96MB raw

| level | deflated | ratio | ms/packet | vs level 4 (bytes) | vs level 4 (cpu) |
|---|---|---|---|---|---|
| 0 | 21,97MB | 1,00x | 0,073 | +2658,3% | 0,06x |
| 1 | 1,08MB | 20,43x | 0,633 | +35,0% | 0,50x |
| **2** | **1,02MB** | **21,61x** | **0,691** | **+27,6%** | **0,55x** |
| 3 | 998,4KB | 22,53x | 0,884 | +22,4% | 0,70x |
| 4 | 815,5KB | 27,58x | 1,264 | — | 1,00x |
| 5 | 776,6KB | 28,96x | 1,563 | -4,8% | 1,24x |
| 6 | 761,2KB | 29,55x | 2,276 | -6,7% | 1,80x |
| 7 | 748,4KB | 30,05x | 2,974 | -8,2% | 2,35x |
| 8 | 735,9KB | 30,56x | 7,568 | -9,8% | 5,99x |
| 9 | 734,2KB | 30,63x | 18,201 | -10,0% | 14,40x |

### Modded world — 36 packets, 177 chunks, 7,91MB raw

Crucible with 15 mods loaded, CustomNPC-Plus among them.

| level | deflated | ratio | ms/packet | vs level 4 (bytes) | vs level 4 (cpu) |
|---|---|---|---|---|---|
| 0 | 7,92MB | 1,00x | 0,059 | +2931,1% | 0,06x |
| 1 | 364,5KB | 22,24x | 0,502 | +36,3% | 0,49x |
| **2** | **344,3KB** | **23,54x** | **0,562** | **+28,7%** | **0,55x** |
| 3 | 328,6KB | 24,66x | 0,703 | +22,9% | 0,69x |
| 4 | 267,4KB | 30,31x | 1,021 | — | 1,00x |
| 5 | 253,8KB | 31,93x | 1,323 | -5,1% | 1,30x |
| 6 | 249,1KB | 32,53x | 1,882 | -6,8% | 1,84x |
| 7 | 244,9KB | 33,10x | 2,343 | -8,4% | 2,29x |
| 8 | 240,7KB | 33,67x | 5,680 | -10,0% | 5,56x |
| 9 | 240,2KB | 33,74x | 13,199 | -10,2% | 12,92x |

## Why the default moves to 2

The two runs agree on the shape, which is the useful part: modding the server changed the absolute
sizes but not the curve.

Going **up** from 4 is close to worthless. Level 9 buys 10% fewer bytes for 14x the CPU, and levels
8 and 9 produce output within 0,2% of each other — the second is pure waste. Whatever argument
existed for 6 does not survive the measurement.

Going **down** is where the trade is real. Level 2 costs 28% more bytes and gives back 45% of the
CPU. On the modded run that is 267KB to 344KB for a 177-chunk join, against 1,02ms to 0,56ms of
netty time per packet. Chunk streaming is bursty — it is concentrated in the seconds after a join or
a teleport, exactly when a server is least able to spare CPU — and bandwidth is the resource most
hosts have to spare. Level 1 is barely cheaper than 2 (0,50x versus 0,55x) for another 8% of bytes,
so 2 is the better end of that step.

Anyone whose constraint is the other way round sets the value back to 4, or higher, and restarts.
